### PR TITLE
fix: Raise ApiError for request errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 0.1.3 - 2024-06-20
+
+### Fixed
+
+- Fixed [bug](https://github.com/PaddleHQ/paddle-python-sdk/issues/10) - raise Paddle API errors
+
 
 ## 0.1.2 - 2024-06-20
 

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -9,6 +9,7 @@ from uuid               import uuid4
 from paddle_billing.FiltersUndefined import FiltersUndefined
 from paddle_billing.HasParameters    import HasParameters
 from paddle_billing.Options          import Options
+from paddle_billing.ResponseParser   import ResponseParser
 
 from paddle_billing.Logger.NullHandler import NullHandler
 
@@ -133,8 +134,17 @@ class Client:
         except RequestException as e:
             self.status_code = e.response.status_code
 
+            api_error = None
+            if e.response is not None:
+                response_parser = ResponseParser(e.response)
+                api_error = response_parser.get_error()
+
             if self.log:
-                self.log.error(f"Request failed: {e}")
+                self.log.error(f"Request failed: {e}. {repr(api_error)}")
+
+            if api_error is not None:
+                raise api_error
+
             raise
 
 

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -140,7 +140,7 @@ class Client:
                 api_error = response_parser.get_error()
 
             if self.log:
-                self.log.error(f"Request failed: {e}.{' ' + repr(api_error) if api_error is not None else ''}")
+                self.log.error(f"Request failed: {e}.{' ' + api_error.detail if api_error is not None else ''}")
 
             if api_error is not None:
                 raise api_error

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -140,7 +140,7 @@ class Client:
                 api_error = response_parser.get_error()
 
             if self.log:
-                self.log.error(f"Request failed: {e}. {repr(api_error)}")
+                self.log.error(f"Request failed: {e}.{' ' + repr(api_error) if api_error is not None else ''}")
 
             if api_error is not None:
                 raise api_error

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -197,7 +197,7 @@ class Client:
             'Authorization':  f"Bearer {self.__api_key}",
             'Content-Type':   'application/json',
             'Paddle-Version': str(self.use_api_version),
-            'User-Agent':     'PaddleSDK/python 0.1.2',
+            'User-Agent':     'PaddleSDK/python 0.1.3',
         })
 
         # Configure retries

--- a/paddle_billing/Exceptions/ApiError.py
+++ b/paddle_billing/Exceptions/ApiError.py
@@ -1,25 +1,27 @@
 from paddle_billing.Exceptions.FieldError import FieldError
 
+from requests import HTTPError
 
-class ApiError(Exception):
-    def __init__(self, error_type, error_code, detail, docs_url, *field_errors):
+class ApiError(HTTPError):
+    def __init__(self, response, error_type, error_code, detail, docs_url, *field_errors):
+        super().__init__(detail, response=response)
         self.error_type   = error_type
         self.error_code   = error_code
         self.detail       = detail
         self.docs_url     = docs_url
         self.field_errors = field_errors
-        super().__init__(self.detail)
 
 
     def __repr__(self):
-        return (f"ApiError(type='{self.error_type}', error_code='{self.error_code}', detail='{self.detail}', "
+        return (f"ApiError(error_type='{self.error_type}', error_code='{self.error_code}', detail='{self.detail}', "
                 f"docs_url='{self.docs_url}', field_errors={self.field_errors})")
 
 
     @classmethod
-    def from_error_data(cls, error):
+    def from_error_data(cls, response, error):
         field_errors = [FieldError(fe['field'], fe['message']) for fe in error.get('errors', [])]
         return cls(
+            response,
             error['type'],
             error['code'],
             error['detail'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version         = '0.1.2',
+    version         = '0.1.3',
 
     author          = 'Paddle and contributors',
     author_email    = 'team-dx@paddle.com',

--- a/tests/Functional/Client/test_Client.py
+++ b/tests/Functional/Client/test_Client.py
@@ -7,7 +7,7 @@ from paddle_billing.Exceptions.ApiErrors.AddressApiError import AddressApiError
 
 from requests.exceptions import RequestException, HTTPError
 
-from tests.Utils.TestClient import mock_requests, test_client
+from tests.Utils.TestLogger import test_log_handler, LogHandler
 
 
 class TestClient:
@@ -83,6 +83,7 @@ class TestClient:
     def test_post_raw_returns_error_response(
         self,
         test_client,
+        test_log_handler: LogHandler,
         mock_requests,
         expected_response_status,
         expected_reason,
@@ -132,3 +133,6 @@ class TestClient:
             f"docs_url='{api_error.docs_url}', "
             f"field_errors={api_error.field_errors}"
             ")")
+
+        assert test_log_handler.get_logs()[0].message == \
+            f"Request failed: {expected_response_status} Client Error: {expected_reason} for url: {expected_request_url}. {repr(api_error)}"

--- a/tests/Functional/Client/test_Client.py
+++ b/tests/Functional/Client/test_Client.py
@@ -135,4 +135,4 @@ class TestClient:
             ")")
 
         assert test_log_handler.get_logs()[0].message == \
-            f"Request failed: {expected_response_status} Client Error: {expected_reason} for url: {expected_request_url}. {repr(api_error)}"
+            f"Request failed: {expected_response_status} Client Error: {expected_reason} for url: {expected_request_url}. {api_error.detail}"

--- a/tests/Functional/Client/test_Client.py
+++ b/tests/Functional/Client/test_Client.py
@@ -1,0 +1,134 @@
+from json         import loads, dumps
+from pytest       import mark, raises
+from urllib.parse import unquote
+
+from paddle_billing.Exceptions.ApiError                  import ApiError
+from paddle_billing.Exceptions.ApiErrors.AddressApiError import AddressApiError
+
+from requests.exceptions import RequestException, HTTPError
+
+from tests.Utils.TestClient import mock_requests, test_client
+
+
+class TestClient:
+    @mark.parametrize(
+        [
+            'expected_response_status',
+            'expected_reason',
+            'expected_response_body',
+            'expected_exception',
+        ],
+        [
+            (
+                400,
+                'Bad Request',
+                {
+                    "error": {
+                        "type": "request_error",
+                        "code": "bad_request",
+                        "detail": "Invalid request",
+                        "documentation_url": "https://developer.paddle.com/v1/errors/shared/bad_request",
+                        "errors": [
+                            {
+                                "field": "some_field",
+                                "message": "Some error message"
+                            }
+                        ]
+                    },
+                    "meta": {
+                        "request_id": "f00bb3ca-399d-4686-889c-50b028f4c912"
+                    }
+                },
+                ApiError
+            ),
+            (
+                404,
+                'Not Found',
+                {
+                    "error": {
+                        "type": "request_error",
+                        "code": "not_found",
+                        "detail": "Entity not found",
+                        "documentation_url": "https://developer.paddle.com/v1/errors/shared/not_found"
+                    },
+                    "meta": {
+                        "request_id": "f00bb3ca-399d-4686-889c-50b028f4c912"
+                    }
+                },
+                ApiError
+            ),
+            (
+                400,
+                'Bad Request',
+                {
+                    "error": {
+                        "type": "request_error",
+                        "code": "address_location_not_allowed",
+                        "detail": "Cannot create address with an unsupported location",
+                        "documentation_url": "https://developer.paddle.com/errors/addresses/address_location_not_allowed"
+                    },
+                    "meta": {
+                        "request_id": "f00bb3ca-399d-4686-889c-50b028f4c912"
+                    }
+                },
+                AddressApiError
+            ),
+        ],
+        ids=[
+            "Returns bad_request response",
+            "Returns not_found response",
+            "Returns address_location_not_allowed response",
+        ],
+    )
+    def test_post_raw_returns_error_response(
+        self,
+        test_client,
+        mock_requests,
+        expected_response_status,
+        expected_reason,
+        expected_response_body,
+        expected_exception
+    ):
+        expected_request_url = f"{test_client.base_url}/some/url"
+        expected_request_body = { "some_property": "some value" }
+        mock_requests.post(expected_request_url, status_code=expected_response_status, text=dumps(expected_response_body), reason=expected_reason)
+
+        with raises(expected_exception) as exception_info:
+            test_client.client.post_raw(expected_request_url, expected_request_body)
+
+        request_json = test_client.client.payload
+        last_request = mock_requests.last_request
+        api_error    = exception_info.value
+
+        assert unquote(last_request.url) == expected_request_url, \
+            "The URL does not match the expected URL, verify the query string is correct"
+
+        assert loads(request_json) == expected_request_body, \
+            "The request JSON doesn't match the expected fixture JSON"
+
+        assert isinstance(api_error, ApiError)
+        assert isinstance(api_error, HTTPError)
+        assert isinstance(api_error, RequestException)
+        assert api_error.response.status_code == expected_response_status, 'Unexpected status code'
+        assert api_error.error_type == expected_response_body['error']['type']
+        assert api_error.error_code == expected_response_body['error']['code']
+        assert api_error.detail == expected_response_body['error']['detail']
+        assert api_error.docs_url == expected_response_body['error']['documentation_url']
+
+        if 'errors' in expected_response_body['error']:
+            assert len(api_error.field_errors) == len(expected_response_body['error']['errors'])
+
+            for i, expected_field_error in enumerate(expected_response_body['error']['errors']):
+                assert api_error.field_errors[i].field == expected_field_error['field']
+                assert api_error.field_errors[i].error == expected_field_error['message']
+        else:
+            assert len(api_error.field_errors) == 0
+
+        assert str(api_error) == expected_response_body['error']['detail']
+        assert repr(api_error) == ("ApiError("
+            f"error_type='{api_error.error_type}', "
+            f"error_code='{api_error.error_code}', "
+            f"detail='{api_error.detail}', "
+            f"docs_url='{api_error.docs_url}', "
+            f"field_errors={api_error.field_errors}"
+            ")")

--- a/tests/Utils/TestClient.py
+++ b/tests/Utils/TestClient.py
@@ -1,8 +1,11 @@
 from os            import getenv
 from pytest        import fixture
 from requests_mock import Mocker
+from logging       import Logger
 
 from paddle_billing import Client, Environment, Options
+
+from tests.Utils.TestLogger import test_logger
 
 
 class TestClient:
@@ -10,11 +13,12 @@ class TestClient:
         self,
         client:         Client | None = None,
         api_secret_key: str    | None = None,
-        environment:    Environment   = Environment.SANDBOX
+        environment:    Environment   = Environment.SANDBOX,
+        logger:         Logger | None = None,
      ):
         self._environment = environment
         self._base_url    = self._environment.base_url
-        self._client      = client or self.create_client(api_secret_key)
+        self._client      = client or self.create_client(api_secret_key, logger)
 
 
     @property
@@ -30,16 +34,17 @@ class TestClient:
         return self._environment
 
 
-    def create_client(self, api_secret_key: str | None = None):
+    def create_client(self, api_secret_key: str | None = None, logger: Logger | None = None):
         return Client(
             getenv('PADDLE_API_SECRET_KEY') if api_secret_key is None else api_secret_key,
             options = Options(self._environment),
+            logger=logger
         )
 
 
 @fixture(autouse=True)
-def test_client():
-    return TestClient(environment=Environment.SANDBOX)
+def test_client(test_logger):
+    return TestClient(environment=Environment.SANDBOX, logger=test_logger)
 
 
 @fixture

--- a/tests/Utils/TestLogger.py
+++ b/tests/Utils/TestLogger.py
@@ -1,0 +1,28 @@
+from pytest  import fixture
+from logging import getLogger, Logger, Handler, LogRecord
+
+
+class LogHandler(Handler):
+    def __init__(self):
+        super().__init__()
+        self._logs = []
+
+
+    def emit(self, record):
+        self._logs.append(record)
+
+
+    def get_logs(self) -> list[LogRecord]:
+        return self._logs
+
+
+@fixture
+def test_log_handler() -> LogHandler:
+    return LogHandler()
+
+
+@fixture
+def test_logger(test_log_handler) -> Logger:
+    logger = getLogger('paddle_test_logger')
+    logger.addHandler(test_log_handler)
+    return logger

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+from tests.Utils.TestClient import mock_requests, test_client
+from tests.Utils.TestLogger import test_log_handler, test_logger


### PR DESCRIPTION
### Fixed
- `Client._make_request` now raises an `ApiError` (or resolved sub class if implemented, e.g. `AddressApiError`), which provides the following properties:
  - `error_type`
  - `error_code`
  - `detail`
  - `docs_url`
  - `field_errors` (list)
    - `field`
    - `error`
- `ApiError` extends `requests.HTTPError` and so also has `response` object available.
- `Client._make_request` now logs `repr(api_error)` to provide more detail about the error.

---

Relates to https://github.com/PaddleHQ/paddle-python-sdk/issues/10
