### PR TITLE
fix!: Make entity factory methods static

### DIFF
--- a/paddle_billing/Entities/Address.py
+++ b/paddle_billing/Entities/Address.py
@@ -24,8 +24,8 @@ class Address(Entity):
     import_meta:  ImportMeta | None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Address:
+    @staticmethod
+    def from_dict(data: dict) -> Address:
         return Address(
             id           = data['id'],
             customer_id  = data['customer_id'],

--- a/paddle_billing/Entities/Adjustment.py
+++ b/paddle_billing/Entities/Adjustment.py
@@ -25,8 +25,8 @@ class Adjustment(Entity):
     updated_at:                datetime | None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Adjustment:
+    @staticmethod
+    def from_dict(data: dict) -> Adjustment:
         return Adjustment(
             id                        = data['id'],
             action                    = Action(data['action']),

--- a/paddle_billing/Entities/Business.py
+++ b/paddle_billing/Entities/Business.py
@@ -21,8 +21,8 @@ class Business(Entity):
     import_meta:    ImportMeta | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Business:
+    @staticmethod
+    def from_dict(data: dict) -> Business:
         return Business(
             id             = data['id'],
             customer_id    = data['customer_id'],

--- a/paddle_billing/Entities/CreditBalance.py
+++ b/paddle_billing/Entities/CreditBalance.py
@@ -13,8 +13,8 @@ class CreditBalance(Entity):
     balance:       AdjustmentCustomerBalance
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> CreditBalance:
+    @staticmethod
+    def from_dict(data: dict) -> CreditBalance:
         return CreditBalance(
             customer_id   = data['customer_id'],
             currency_code = CurrencyCode(data['currency_code']),

--- a/paddle_billing/Entities/Customer.py
+++ b/paddle_billing/Entities/Customer.py
@@ -20,8 +20,8 @@ class Customer(Entity):
     import_meta:       ImportMeta | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Customer:
+    @staticmethod
+    def from_dict(data: dict) -> Customer:
         return Customer(
             id                = data['id'],
             name              = data.get('name'),

--- a/paddle_billing/Entities/Discount.py
+++ b/paddle_billing/Entities/Discount.py
@@ -28,8 +28,8 @@ class Discount(Entity):
     import_meta:                 ImportMeta | None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Discount:
+    @staticmethod
+    def from_dict(data: dict) -> Discount:
         return Discount(
             id                          = data['id'],
             status                      = DiscountStatus(data['status']),

--- a/paddle_billing/Entities/Entity.py
+++ b/paddle_billing/Entities/Entity.py
@@ -3,9 +3,9 @@ from abc        import ABC, abstractmethod
 
 
 class Entity(ABC):
-    @classmethod
+    @staticmethod
     @abstractmethod
-    def from_dict(cls, data: dict):
+    def from_dict(data: dict):
         """
         A static factory for the entity that conforms to the Paddle API.
         """

--- a/paddle_billing/Entities/Event.py
+++ b/paddle_billing/Entities/Event.py
@@ -20,8 +20,8 @@ class Event(Entity, ABC):
     data:        NotificationEntity
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Event:
+    @staticmethod
+    def from_dict(data: dict) -> Event:
         _type = data['event_type'].split('.')[0] or ''
 
         entity_class_name  = data['event_type'].split('.')[0].lower().title()

--- a/paddle_billing/Entities/EventType.py
+++ b/paddle_billing/Entities/EventType.py
@@ -13,8 +13,8 @@ class EventType(Entity):
     available_versions: list
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> EventType:
+    @staticmethod
+    def from_dict(data: dict) -> EventType:
         return EventType(
             name               = EventTypeName(data['name']),
             description        = data['description'],

--- a/paddle_billing/Entities/Notification.py
+++ b/paddle_billing/Entities/Notification.py
@@ -24,8 +24,8 @@ class Notification(Entity):
     notification_setting_id: str
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Notification:
+    @staticmethod
+    def from_dict(data: dict) -> Notification:
         return Notification(
             id                      = data['id'],
             type                    = EventTypeName(data['type']),

--- a/paddle_billing/Entities/NotificationLog.py
+++ b/paddle_billing/Entities/NotificationLog.py
@@ -14,8 +14,8 @@ class NotificationLog(Entity):
     attempted_at:          datetime
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> NotificationLog:
+    @staticmethod
+    def from_dict(data: dict) -> NotificationLog:
         return NotificationLog(
             id                    = data['id'],
             response_code         = data['response_code'],

--- a/paddle_billing/Entities/NotificationSetting.py
+++ b/paddle_billing/Entities/NotificationSetting.py
@@ -19,8 +19,8 @@ class NotificationSetting(Entity):
     endpoint_secret_key:      str
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> NotificationSetting:
+    @staticmethod
+    def from_dict(data: dict) -> NotificationSetting:
         return NotificationSetting(
             id                       = data['id'],
             description              = data['description'],

--- a/paddle_billing/Entities/Notifications/NotificationPayout.py
+++ b/paddle_billing/Entities/Notifications/NotificationPayout.py
@@ -14,8 +14,8 @@ class NotificationPayout(Entity):
     currency_code: CurrencyCodePayouts
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> NotificationPayout:
+    @staticmethod
+    def from_dict(data: dict) -> NotificationPayout:
         return NotificationPayout(
             id            = data['id'],
             status        = NotificationPayoutStatus(data['status']),

--- a/paddle_billing/Entities/Price.py
+++ b/paddle_billing/Entities/Price.py
@@ -40,8 +40,8 @@ class Price(Entity):
     updated_at:           datetime
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Price:
+    @staticmethod
+    def from_dict(data: dict) -> Price:
         return Price(
             id                   = data['id'],
             product_id           = data['product_id'],

--- a/paddle_billing/Entities/PricePreview.py
+++ b/paddle_billing/Entities/PricePreview.py
@@ -19,8 +19,8 @@ class PricePreview(Entity):
     available_payment_methods: list[AvailablePaymentMethods]
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> PricePreview:
+    @staticmethod
+    def from_dict(data: dict) -> PricePreview:
         return PricePreview(
             customer_id               = data.get('customer_id'),
             address_id                = data.get('address_id'),

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewDetails.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewDetails.py
@@ -10,6 +10,6 @@ class PricePreviewDetails(Entity):
     line_items: list[PricePreviewLineItem]
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> PricePreviewDetails:
+    @staticmethod
+    def from_dict(data: dict) -> PricePreviewDetails:
         return PricePreviewDetails(line_items=[PricePreviewLineItem.from_dict(item) for item in data['line_items']])

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewDiscounts.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewDiscounts.py
@@ -11,8 +11,8 @@ class PricePreviewDiscounts:
     formatted_total: str
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> PricePreviewDiscounts:
+    @staticmethod
+    def from_dict(data: dict) -> PricePreviewDiscounts:
         return PricePreviewDiscounts(
             discount        = Discount.from_dict(data['discount']),
             total           = data['total'],

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewItem.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewItem.py
@@ -8,8 +8,8 @@ class PricePreviewItem:
     quantity: int
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> PricePreviewItem:
+    @staticmethod
+    def from_dict(data: dict) -> PricePreviewItem:
         return PricePreviewItem(
             price_id = data['price_id'],
             quantity = data['quantity'],

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewLineItem.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewLineItem.py
@@ -23,8 +23,8 @@ class PricePreviewLineItem:
     discounts:             list[PricePreviewDiscounts]
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> PricePreviewLineItem:
+    @staticmethod
+    def from_dict(data: dict) -> PricePreviewLineItem:
         return PricePreviewLineItem(
             price                 = Price.from_dict(data['price']),
             quantity              = data['quantity'],

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewTotalsFormatted.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewTotalsFormatted.py
@@ -10,8 +10,8 @@ class PricePreviewTotalsFormatted:
     total:    str
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> PricePreviewTotalsFormatted:
+    @staticmethod
+    def from_dict(data: dict) -> PricePreviewTotalsFormatted:
         return PricePreviewTotalsFormatted(
             subtotal = data['subtotal'],
             discount = data['discount'],

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewUnitTotalsFormatted.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewUnitTotalsFormatted.py
@@ -10,8 +10,8 @@ class PricePreviewUnitTotalsFormatted:
     total:    str
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> PricePreviewUnitTotalsFormatted:
+    @staticmethod
+    def from_dict(data: dict) -> PricePreviewUnitTotalsFormatted:
         return PricePreviewUnitTotalsFormatted(
             subtotal = data['subtotal'],
             discount = data['discount'],

--- a/paddle_billing/Entities/Product.py
+++ b/paddle_billing/Entities/Product.py
@@ -22,8 +22,8 @@ class Product(Entity):
     type:         CatalogType | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Product:
+    @staticmethod
+    def from_dict(data: dict) -> Product:
         return Product(
             description  = data.get('description'),
             id           = data['id'],

--- a/paddle_billing/Entities/Report.py
+++ b/paddle_billing/Entities/Report.py
@@ -18,8 +18,8 @@ class Report(Entity):
     updated_at: datetime
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Report:
+    @staticmethod
+    def from_dict(data: dict) -> Report:
         return Report(
             id         = data['id'],
             status     = ReportStatus(data['status']),

--- a/paddle_billing/Entities/ReportCSV.py
+++ b/paddle_billing/Entities/ReportCSV.py
@@ -8,6 +8,6 @@ from paddle_billing.Entities.Entity import Entity
 class ReportCSV(Entity):
     url: str
 
-    @classmethod
-    def from_dict(cls, data: dict) -> ReportCSV:
+    @staticmethod
+    def from_dict(data: dict) -> ReportCSV:
         return ReportCSV(url=data['url'])

--- a/paddle_billing/Entities/Shared/ImportMeta.py
+++ b/paddle_billing/Entities/Shared/ImportMeta.py
@@ -8,8 +8,8 @@ class ImportMeta:
     imported_from: str
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> ImportMeta:
+    @staticmethod
+    def from_dict(data: dict) -> ImportMeta:
         return ImportMeta(
             external_id   = data.get('external_id'),
             imported_from = data['imported_from'],

--- a/paddle_billing/Entities/Shared/MethodDetails.py
+++ b/paddle_billing/Entities/Shared/MethodDetails.py
@@ -11,8 +11,8 @@ class MethodDetails:
     card: Card | None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> MethodDetails:
+    @staticmethod
+    def from_dict(data: dict) -> MethodDetails:
         return MethodDetails(
             PaymentMethodType(data['type']),
             Card.from_dict(data['card']) if data.get('card') else None,

--- a/paddle_billing/Entities/Subscription.py
+++ b/paddle_billing/Entities/Subscription.py
@@ -54,8 +54,8 @@ class Subscription(Entity):
     custom_data:                   CustomData                  | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Subscription:
+    @staticmethod
+    def from_dict(data: dict) -> Subscription:
         return Subscription(
             id                     = data['id'],
             status                 = SubscriptionStatus(data['status']),

--- a/paddle_billing/Entities/SubscriptionPreview.py
+++ b/paddle_billing/Entities/SubscriptionPreview.py
@@ -48,8 +48,8 @@ class SubscriptionPreview(Entity):
     update_summary:                SubscriptionPreviewSubscriptionUpdateSummary | None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> SubscriptionPreview:
+    @staticmethod
+    def from_dict(data: dict) -> SubscriptionPreview:
         return SubscriptionPreview(
             status                        = SubscriptionStatus(data['status']),
             customer_id                   = data['customer_id'],

--- a/paddle_billing/Entities/Transaction.py
+++ b/paddle_billing/Entities/Transaction.py
@@ -61,8 +61,8 @@ class Transaction(Entity):
     receipt_data:              str                                | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Transaction:
+    @staticmethod
+    def from_dict(data: dict) -> Transaction:
         return Transaction(
             address_id      = data.get('address_id'),
             business_id     = data.get('business_id'),

--- a/paddle_billing/Entities/TransactionData.py
+++ b/paddle_billing/Entities/TransactionData.py
@@ -9,7 +9,7 @@ class TransactionData(Entity):
     url: str
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> TransactionData:
+    @staticmethod
+    def from_dict(data: dict) -> TransactionData:
         return TransactionData(data['url'])
 

--- a/paddle_billing/Entities/TransactionPreview.py
+++ b/paddle_billing/Entities/TransactionPreview.py
@@ -23,8 +23,8 @@ class TransactionPreview(Entity):
     available_payment_methods: list[AvailablePaymentMethods]
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> TransactionPreview:
+    @staticmethod
+    def from_dict(data: dict) -> TransactionPreview:
         return TransactionPreview(
             customer_id               = data.get('customer_id'),
             address_id                = data.get('address_id'),

--- a/paddle_billing/Notifications/Entities/Address.py
+++ b/paddle_billing/Notifications/Entities/Address.py
@@ -24,8 +24,8 @@ class Address(Entity):
     customer_id:  str        | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Address:
+    @staticmethod
+    def from_dict(data: dict) -> Address:
         return Address(
             id           = data['id'],
             customer_id  = data.get('customer_id'),

--- a/paddle_billing/Notifications/Entities/Adjustment.py
+++ b/paddle_billing/Notifications/Entities/Adjustment.py
@@ -25,8 +25,8 @@ class Adjustment(Entity):
     updated_at:                datetime | None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Adjustment:
+    @staticmethod
+    def from_dict(data: dict) -> Adjustment:
         return Adjustment(
             id                        = data['id'],
             action                    = Action(data['action']),

--- a/paddle_billing/Notifications/Entities/Business.py
+++ b/paddle_billing/Notifications/Entities/Business.py
@@ -22,8 +22,8 @@ class Business(Entity):
     customer_id:    str        | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Business:
+    @staticmethod
+    def from_dict(data: dict) -> Business:
         return Business(
             id             = data['id'],
             customer_id    = data.get('customer_id'),

--- a/paddle_billing/Notifications/Entities/Customer.py
+++ b/paddle_billing/Notifications/Entities/Customer.py
@@ -20,8 +20,8 @@ class Customer(Entity):
     import_meta:       ImportMeta | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Customer:
+    @staticmethod
+    def from_dict(data: dict) -> Customer:
         return Customer(
             id                = data['id'],
             name              = data.get('name'),

--- a/paddle_billing/Notifications/Entities/Discount.py
+++ b/paddle_billing/Notifications/Entities/Discount.py
@@ -28,8 +28,8 @@ class Discount(Entity):
     usage_limit:                 int          | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Discount:
+    @staticmethod
+    def from_dict(data: dict) -> Discount:
         return Discount(
             amount                      = data['amount'],
             code                        = data.get('code'),

--- a/paddle_billing/Notifications/Entities/Entity.py
+++ b/paddle_billing/Notifications/Entities/Entity.py
@@ -3,9 +3,9 @@ from abc        import ABC, abstractmethod
 
 
 class Entity(ABC):
-    @classmethod
+    @staticmethod
     @abstractmethod
-    def from_dict(cls, data: dict):
+    def from_dict(data: dict):
         """
         A static factory for the entity that conforms to the Paddle API.
         """

--- a/paddle_billing/Notifications/Entities/Payout.py
+++ b/paddle_billing/Notifications/Entities/Payout.py
@@ -14,8 +14,8 @@ class Payout(Entity):
     status:        PayoutStatus
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Payout:
+    @staticmethod
+    def from_dict(data: dict) -> Payout:
         return Payout(
             amount        = data['amount'],
             id            = data['id'],

--- a/paddle_billing/Notifications/Entities/Product.py
+++ b/paddle_billing/Notifications/Entities/Product.py
@@ -22,8 +22,8 @@ class Product(Entity):
     updated_at:   datetime    | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Product:
+    @staticmethod
+    def from_dict(data: dict) -> Product:
         return Product(
             description  = data.get('description'),
             id           = data['id'],

--- a/paddle_billing/Notifications/Entities/Report.py
+++ b/paddle_billing/Notifications/Entities/Report.py
@@ -18,8 +18,8 @@ class Report(Entity):
     updated_at: datetime
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Report:
+    @staticmethod
+    def from_dict(data: dict) -> Report:
         return Report(
             id         = data['id'],
             status     = ReportStatus(data['status']),

--- a/paddle_billing/Notifications/Entities/Shared/ImportMeta.py
+++ b/paddle_billing/Notifications/Entities/Shared/ImportMeta.py
@@ -8,8 +8,8 @@ class ImportMeta:
     imported_from: str
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> ImportMeta:
+    @staticmethod
+    def from_dict(data: dict) -> ImportMeta:
         return ImportMeta(
             external_id   = data.get('external_id'),
             imported_from = data['imported_from'],

--- a/paddle_billing/Notifications/Entities/Shared/MethodDetails.py
+++ b/paddle_billing/Notifications/Entities/Shared/MethodDetails.py
@@ -11,8 +11,8 @@ class MethodDetails:
     card: Card | None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> MethodDetails:
+    @staticmethod
+    def from_dict(data: dict) -> MethodDetails:
         return MethodDetails(
             PaymentMethodType(data['type']),
             Card.from_dict(data['card']) if data.get('card') else None,

--- a/paddle_billing/Notifications/Entities/Subscription.py
+++ b/paddle_billing/Notifications/Entities/Subscription.py
@@ -47,8 +47,8 @@ class Subscription(Entity):
     transaction_id:         str                         | None = None  # Only provided by subscription.created
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Subscription:
+    @staticmethod
+    def from_dict(data: dict) -> Subscription:
         return Subscription(
             id                     = data['id'],
             transaction_id         = data.get('transaction_id'),

--- a/paddle_billing/Notifications/Entities/Transaction.py
+++ b/paddle_billing/Notifications/Entities/Transaction.py
@@ -46,8 +46,8 @@ class Transaction(Entity):
     receipt_data:              str      | None = None
 
 
-    @classmethod
-    def from_dict(cls, data: dict) -> Transaction:
+    @staticmethod
+    def from_dict(data: dict) -> Transaction:
         return Transaction(
             address_id      = data.get('address_id'),
             business_id     = data.get('business_id'),


### PR DESCRIPTION
Entity factories `from_dict` should not need class context, it's behaviour should always be within the confines of a static context.

BREAKING CHANGE: Factory methods are no longer callable as class methods