### PR TITLE
feat: Support disposition query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - Support for `custom_data` on discounts
 - Support notification settings pagination, see [related changelog](https://developer.paddle.com/changelog/2024/notification-settings-pagination)
 - Support notification settings `active` filter
+- `TransactionsClient.get_invoice_pdf` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)
 
 ### Changed
 

--- a/paddle_billing/Entities/Shared/Disposition.py
+++ b/paddle_billing/Entities/Shared/Disposition.py
@@ -1,0 +1,6 @@
+from paddle_billing.PaddleStrEnum import PaddleStrEnum, PaddleStrEnumMeta
+
+
+class Disposition(PaddleStrEnum, metaclass=PaddleStrEnumMeta):
+    Attachment: "Attachment"   = 'attachment'
+    Inline: "Inline" = 'inline'

--- a/paddle_billing/Entities/Shared/__init__.py
+++ b/paddle_billing/Entities/Shared/__init__.py
@@ -21,6 +21,7 @@ from paddle_billing.Entities.Shared.CurrencyCodeAdjustments         import Curre
 from paddle_billing.Entities.Shared.CurrencyCodePayouts             import CurrencyCodePayouts
 from paddle_billing.Entities.Shared.CustomData                      import CustomData
 from paddle_billing.Entities.Shared.Data                            import Data
+from paddle_billing.Entities.Shared.Disposition                     import Disposition
 from paddle_billing.Entities.Shared.ErrorCode                       import ErrorCode
 from paddle_billing.Entities.Shared.ImportMeta                      import ImportMeta
 from paddle_billing.Entities.Shared.Interval                        import Interval

--- a/paddle_billing/Resources/Transactions/Operations/GetTransactionInvoice.py
+++ b/paddle_billing/Resources/Transactions/Operations/GetTransactionInvoice.py
@@ -1,0 +1,20 @@
+from paddle_billing.HasParameters import HasParameters
+
+from paddle_billing.Entities.Shared import Disposition
+
+
+class GetTransactionInvoice(HasParameters):
+    def __init__(
+        self,
+        disposition: Disposition | None = None,
+    ):
+        self.disposition = disposition
+
+
+    def get_parameters(self) -> dict:
+        parameters = {}
+
+        if self.disposition:
+            parameters['disposition'] = self.disposition.value
+
+        return parameters

--- a/paddle_billing/Resources/Transactions/Operations/__init__.py
+++ b/paddle_billing/Resources/Transactions/Operations/__init__.py
@@ -1,6 +1,7 @@
-from paddle_billing.Resources.Transactions.Operations.CreateTransaction  import CreateTransaction
-from paddle_billing.Resources.Transactions.Operations.ListTransactions   import ListTransactions
-from paddle_billing.Resources.Transactions.Operations.List.Includes      import Includes as TransactionIncludes
-from paddle_billing.Resources.Transactions.Operations.List.Origin        import Origin   as TransactionOrigin
-from paddle_billing.Resources.Transactions.Operations.PreviewTransaction import PreviewTransaction
-from paddle_billing.Resources.Transactions.Operations.UpdateTransaction  import UpdateTransaction
+from paddle_billing.Resources.Transactions.Operations.CreateTransaction     import CreateTransaction
+from paddle_billing.Resources.Transactions.Operations.ListTransactions      import ListTransactions
+from paddle_billing.Resources.Transactions.Operations.List.Includes         import Includes as TransactionIncludes
+from paddle_billing.Resources.Transactions.Operations.List.Origin           import Origin   as TransactionOrigin
+from paddle_billing.Resources.Transactions.Operations.PreviewTransaction    import PreviewTransaction
+from paddle_billing.Resources.Transactions.Operations.UpdateTransaction     import UpdateTransaction
+from paddle_billing.Resources.Transactions.Operations.GetTransactionInvoice import GetTransactionInvoice

--- a/paddle_billing/Resources/Transactions/TransactionsClient.py
+++ b/paddle_billing/Resources/Transactions/TransactionsClient.py
@@ -13,6 +13,7 @@ from paddle_billing.Resources.Transactions.Operations import (
     UpdateTransaction,
     PreviewTransaction,
     TransactionIncludes,
+    GetTransactionInvoice,
 )
 
 from typing import TYPE_CHECKING
@@ -83,8 +84,8 @@ class TransactionsClient:
         return TransactionPreview.from_dict(parser.get_data())
 
 
-    def get_invoice_pdf(self, transaction_id: str) -> TransactionData:
-        self.response = self.client.get_raw(f"/transactions/{transaction_id}/invoice")
+    def get_invoice_pdf(self, transaction_id: str, operation: GetTransactionInvoice = None) -> TransactionData:
+        self.response = self.client.get_raw(f"/transactions/{transaction_id}/invoice", operation)
         parser        = ResponseParser(self.response)
 
         return TransactionData.from_dict(parser.get_data())


### PR DESCRIPTION
### Added
- `TransactionsClient.get_invoice_pdf` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)