### PR TITLE
feat: Add import_meta to SubscriptionClient preview responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,15 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - Support notification settings pagination, see [related changelog](https://developer.paddle.com/changelog/2024/notification-settings-pagination)
 - Support notification settings `active` filter
 - `TransactionsClient.get_invoice_pdf` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)
+- `SubscriptionClient` `preview_update` and `preview_one_time_charge` responses now have `import_meta` property
 
 ### Changed
 
 - `paddle_billing.Entities.Shared.CustomData` is no longer a `dataclass`
+
+### Fixed
+
+- `PreviewPrice` operation no longer allows empty `items`
 
 ## 0.2.2 - 2024-09-03
 

--- a/paddle_billing/Entities/SubscriptionPreview.py
+++ b/paddle_billing/Entities/SubscriptionPreview.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from datetime    import datetime
 
 from paddle_billing.Entities.Entity import Entity
-from paddle_billing.Entities.Shared import BillingDetails, CollectionMode, CurrencyCode, CustomData, TimePeriod
+from paddle_billing.Entities.Shared import BillingDetails, CollectionMode, CurrencyCode, CustomData, TimePeriod, ImportMeta
 
 from paddle_billing.Entities.Shared.TransactionDetailsPreview import TransactionDetailsPreview
 
@@ -46,6 +46,7 @@ class SubscriptionPreview(Entity):
     next_transaction:              SubscriptionNextTransaction | None
     recurring_transaction_details: TransactionDetailsPreview   | None
     update_summary:                SubscriptionPreviewSubscriptionUpdateSummary | None
+    import_meta:                   ImportMeta | None
 
 
     @staticmethod
@@ -76,4 +77,5 @@ class SubscriptionPreview(Entity):
             next_transaction              = SubscriptionNextTransaction.from_dict(data['next_transaction'])                if data.get('next_transaction')              else None,
             recurring_transaction_details = TransactionDetailsPreview.from_dict(data['recurring_transaction_details'])     if data.get('recurring_transaction_details') else None,
             update_summary                = SubscriptionPreviewSubscriptionUpdateSummary.from_dict(data['update_summary']) if data.get('update_summary')                else None,
+            import_meta                   = ImportMeta.from_dict(data['import_meta'])                                      if data.get('import_meta')                   else None,
         )

--- a/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_charge_full_entity.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_charge_full_entity.json
@@ -378,6 +378,16 @@
           "import_meta": null,
           "created_at": "2023-02-23T13:55:22.538367Z",
           "updated_at": "2023-11-09T14:07:16.051528Z"
+        },
+        "product": {
+          "id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+          "name": "ChatApp Pro",
+          "description": "Everything in basic, plus access to a suite of powerful tools and features designed to take your team's productivity to the next level.",
+          "tax_category": "standard",
+          "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/2nmP8MQSret0aWeDemRw_icon1.png",
+          "status": "active",
+          "created_at": "2023-08-16T14:38:08.3Z",
+          "updated_at": "2023-08-16T14:38:08.3Z"
         }
       },
       {
@@ -415,6 +425,16 @@
           "import_meta": null,
           "created_at": "2023-06-01T13:31:12.625056Z",
           "updated_at": "2023-08-30T10:34:33.862679Z"
+        },
+        "product": {
+          "id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+          "name": "ChatApp Pro",
+          "description": "Everything in basic, plus access to a suite of powerful tools and features designed to take your team's productivity to the next level.",
+          "tax_category": "standard",
+          "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/2nmP8MQSret0aWeDemRw_icon1.png",
+          "status": "active",
+          "created_at": "2023-08-16T14:38:08.3Z",
+          "updated_at": "2023-08-16T14:38:08.3Z"
         }
       }
     ],
@@ -439,7 +459,10 @@
         "currency_code": "USD"
       }
     },
-    "import_meta": null
+    "import_meta": {
+      "external_id": "external-id",
+      "imported_from": "external-platform"
+    }
   },
   "meta": {
     "request_id": "5a10266d-eb36-486c-b9a0-8ec44543ee6d"

--- a/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_update_full_entity.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_update_full_entity.json
@@ -561,7 +561,10 @@
         "currency_code": "USD"
       }
     },
-    "import_meta": null
+    "import_meta": {
+      "external_id": "external-id",
+      "imported_from": "external-platform"
+    }
   },
   "meta": {
     "request_id": "e7181c45-0370-46a9-b405-91783219dda2"


### PR DESCRIPTION
### Added
- `SubscriptionClient` `preview_update` and `preview_one_time_charge` responses now have `import_meta` property