### PR TITLE
fix: Fix filtering of customer credit balances by currency code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 ### Fixed
 
 - `PreviewPrice` operation no longer allows empty `items`
+- `CustomersClient.credit_balances` can now be filtered by `currency_code`
 
 ## 0.2.2 - 2024-09-03
 

--- a/paddle_billing/Resources/Customers/CustomersClient.py
+++ b/paddle_billing/Resources/Customers/CustomersClient.py
@@ -59,7 +59,7 @@ class CustomersClient:
         if operation is None:
             operation = ListCreditBalances()
 
-        self.response = self.client.get_raw(f"/customers/{customer_id}/credit-balances")
+        self.response = self.client.get_raw(f"/customers/{customer_id}/credit-balances", operation)
         parser        = ResponseParser(self.response)
 
         return CreditBalanceCollection.from_list(parser.get_data())

--- a/tests/Functional/Resources/Customers/test_CustomersClient.py
+++ b/tests/Functional/Resources/Customers/test_CustomersClient.py
@@ -4,9 +4,9 @@ from urllib.parse import unquote
 
 from paddle_billing.Entities.Collections import CreditBalanceCollection, CustomerCollection
 from paddle_billing.Entities.Customer    import Customer
-from paddle_billing.Entities.Shared      import CustomData, Status
+from paddle_billing.Entities.Shared      import CustomData, Status, CurrencyCode
 
-from paddle_billing.Resources.Customers.Operations import CreateCustomer, ListCustomers, UpdateCustomer
+from paddle_billing.Resources.Customers.Operations import CreateCustomer, ListCustomers, UpdateCustomer, ListCreditBalances
 from paddle_billing.Resources.Shared.Operations    import Pager
 
 from tests.Utils.TestClient   import mock_requests, test_client
@@ -256,14 +256,26 @@ class TestCustomersClient:
 
 
     @mark.parametrize(
-        'customer_id, expected_response_status, expected_response_body, expected_url',
-        [(
-            'ctm_01h8441jn5pcwrfhwh78jqt8hk',
-            200,
-            ReadsFixtures.read_raw_json_fixture('response/list_credit_balances'),
-            '/customers/ctm_01h8441jn5pcwrfhwh78jqt8hk/credit-balances',
-        )],
-        ids=["List a customer's credit balances"],
+        'customer_id, expected_response_status, expected_response_body, expected_path, operation',
+        [
+            (
+                'ctm_01h8441jn5pcwrfhwh78jqt8hk',
+                200,
+                ReadsFixtures.read_raw_json_fixture('response/list_credit_balances'),
+                '/customers/ctm_01h8441jn5pcwrfhwh78jqt8hk/credit-balances',
+                None,
+            ), (
+                'ctm_01h8441jn5pcwrfhwh78jqt8hk',
+                200,
+                ReadsFixtures.read_raw_json_fixture('response/list_credit_balances'),
+                '/customers/ctm_01h8441jn5pcwrfhwh78jqt8hk/credit-balances?currency_code=USD,GBP',
+                ListCreditBalances([CurrencyCode.USD, CurrencyCode.GBP]),
+            ),
+        ],
+        ids=[
+            "List a customer's credit balances",
+            "List a customer's credit balances for currency code"
+        ],
     )
     def test_list_credit_balance_customers_returns_expected_response(
         self,
@@ -272,12 +284,13 @@ class TestCustomersClient:
         customer_id,
         expected_response_status,
         expected_response_body,
-        expected_url,
+        expected_path,
+        operation,
     ):
-        expected_url = f"{test_client.base_url}{expected_url}"
+        expected_url = f"{test_client.base_url}{expected_path}"
         mock_requests.get(expected_url, status_code=expected_response_status, text=expected_response_body)
 
-        response      = test_client.client.customers.credit_balances(customer_id)
+        response      = test_client.client.customers.credit_balances(customer_id, operation)
         response_json = test_client.client.customers.response.json()
         last_request  = mock_requests.last_request
 


### PR DESCRIPTION
### Fixed
- `CustomersClient.credit_balances` can now be filtered by `currency_code`