### PR TITLE
feat: AvailablePaymentMethods now supports offline, unknown and wire_transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - `TransactionsClient.get_invoice_pdf` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)
 - `SubscriptionClient` `preview_update` and `preview_one_time_charge` responses now have `import_meta` property
 - Support for `tax_rates_used` on Adjustments
+- `AvailablePaymentMethods` now supports `offline`, `unknown` and `wire_transfer`
 
 ### Changed
 

--- a/paddle_billing/Entities/Shared/AvailablePaymentMethods.py
+++ b/paddle_billing/Entities/Shared/AvailablePaymentMethods.py
@@ -2,10 +2,13 @@ from paddle_billing.PaddleStrEnum import PaddleStrEnum, PaddleStrEnumMeta
 
 
 class AvailablePaymentMethods(PaddleStrEnum, metaclass=PaddleStrEnumMeta):
-    Alipay: "AvailablePaymentMethods"     = 'alipay'
-    ApplePay: "AvailablePaymentMethods"   = 'apple_pay'
-    Bancontact: "AvailablePaymentMethods" = 'bancontact'
-    Card: "AvailablePaymentMethods"       = 'card'
-    GooglePay: "AvailablePaymentMethods"  = 'google_pay'
-    Ideal: "AvailablePaymentMethods"      = 'ideal'
-    Paypal: "AvailablePaymentMethods"     = 'paypal'
+    Alipay: "AvailablePaymentMethods"       = 'alipay'
+    ApplePay: "AvailablePaymentMethods"     = 'apple_pay'
+    Bancontact: "AvailablePaymentMethods"   = 'bancontact'
+    Card: "AvailablePaymentMethods"         = 'card'
+    GooglePay: "AvailablePaymentMethods"    = 'google_pay'
+    Ideal: "AvailablePaymentMethods"        = 'ideal'
+    Offline: "AvailablePaymentMethods"      = 'offline'
+    Paypal: "AvailablePaymentMethods"       = 'paypal'
+    Unknown: "AvailablePaymentMethods"      = 'unknown'
+    WireTransfer: "AvailablePaymentMethods" = 'wire_transfer'

--- a/paddle_billing/Notifications/Entities/Shared/AvailablePaymentMethods.py
+++ b/paddle_billing/Notifications/Entities/Shared/AvailablePaymentMethods.py
@@ -2,10 +2,13 @@ from paddle_billing.PaddleStrEnum import PaddleStrEnum, PaddleStrEnumMeta
 
 
 class AvailablePaymentMethods(PaddleStrEnum, metaclass=PaddleStrEnumMeta):
-    Alipay: "AvailablePaymentMethods"     = 'alipay'
-    ApplePay: "AvailablePaymentMethods"   = 'apple_pay'
-    Bancontact: "AvailablePaymentMethods" = 'bancontact'
-    Card: "AvailablePaymentMethods"       = 'card'
-    GooglePay: "AvailablePaymentMethods"  = 'google_pay'
-    Ideal: "AvailablePaymentMethods"      = 'ideal'
-    Paypal: "AvailablePaymentMethods"     = 'paypal'
+    Alipay: "AvailablePaymentMethods"       = 'alipay'
+    ApplePay: "AvailablePaymentMethods"     = 'apple_pay'
+    Bancontact: "AvailablePaymentMethods"   = 'bancontact'
+    Card: "AvailablePaymentMethods"         = 'card'
+    GooglePay: "AvailablePaymentMethods"    = 'google_pay'
+    Ideal: "AvailablePaymentMethods"        = 'ideal'
+    Offline: "AvailablePaymentMethods"      = 'offline'
+    Paypal: "AvailablePaymentMethods"       = 'paypal'
+    Unknown: "AvailablePaymentMethods"      = 'unknown'
+    WireTransfer: "AvailablePaymentMethods" = 'wire_transfer'

--- a/tests/Functional/Resources/Subscriptions/_fixtures/response/get_payment_method_change_transaction_entity.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/response/get_payment_method_change_transaction_entity.json
@@ -192,7 +192,19 @@
       "custom_data": {
           "key": "value"
       }
-  }
+    },
+    "available_payment_methods": [
+      "alipay",
+      "apple_pay",
+      "bancontact",
+      "card",
+      "google_pay",
+      "ideal",
+      "offline",
+      "paypal",
+      "unknown",
+      "wire_transfer"
+    ]
   },
   "meta": {
     "request_id": "e4747324-738b-4707-ac7a-7eaabb7c7a26"

--- a/tests/Functional/Resources/Subscriptions/test_SubscriptionsClient.py
+++ b/tests/Functional/Resources/Subscriptions/test_SubscriptionsClient.py
@@ -10,6 +10,7 @@ from paddle_billing.Entities.Transaction         import Transaction
 from paddle_billing.Entities.Discount            import Discount, DiscountStatus
 
 from paddle_billing.Entities.Shared import (
+    AvailablePaymentMethods,
     CollectionMode,
     CurrencyCode,
     CustomData,
@@ -615,6 +616,34 @@ class TestSubscriptionsClient:
         assert discount.updated_at.isoformat() == '2023-08-18T08:51:07.596000+00:00'
         assert isinstance(discount.custom_data, CustomData)
         assert discount.custom_data.data.get('key') == 'value'
+
+
+    def test_get_payment_method_change_transaction_returns_transaction_with_available_payment_methods(
+        self,
+        test_client,
+        mock_requests,
+    ):
+        mock_requests.get(
+            f"{test_client.base_url}/subscriptions/sub_01h7zcgmdc6tmwtjehp3sh7azf/update-payment-method-transaction",
+            status_code=200,
+            text=ReadsFixtures.read_raw_json_fixture('response/get_payment_method_change_transaction_entity'),
+        )
+
+        response = test_client.client.subscriptions.get_payment_method_change_transaction('sub_01h7zcgmdc6tmwtjehp3sh7azf')
+
+        assert isinstance(response, Transaction)
+
+        available_payment_methods = response.available_payment_methods
+        assert available_payment_methods[0] == AvailablePaymentMethods.Alipay
+        assert available_payment_methods[1] == AvailablePaymentMethods.ApplePay
+        assert available_payment_methods[2] == AvailablePaymentMethods.Bancontact
+        assert available_payment_methods[3] == AvailablePaymentMethods.Card
+        assert available_payment_methods[4] == AvailablePaymentMethods.GooglePay
+        assert available_payment_methods[5] == AvailablePaymentMethods.Ideal
+        assert available_payment_methods[6] == AvailablePaymentMethods.Offline
+        assert available_payment_methods[7] == AvailablePaymentMethods.Paypal
+        assert available_payment_methods[8] == AvailablePaymentMethods.Unknown
+        assert available_payment_methods[9] == AvailablePaymentMethods.WireTransfer
 
 
     @mark.parametrize(

--- a/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
@@ -186,7 +186,19 @@
       "custom_data": {
           "key": "value"
       }
-    }
+    },
+    "available_payment_methods": [
+      "alipay",
+      "apple_pay",
+      "bancontact",
+      "card",
+      "google_pay",
+      "ideal",
+      "offline",
+      "paypal",
+      "unknown",
+      "wire_transfer"
+    ]
   },
   "meta": {
     "request_id": "0daa7c59-f2eb-41b6-bf2e-bb3b070873a5"

--- a/tests/Functional/Resources/Transactions/test_TransactionsClient.py
+++ b/tests/Functional/Resources/Transactions/test_TransactionsClient.py
@@ -11,6 +11,7 @@ from paddle_billing.Resources.Shared.Operations import Comparator, DateCompariso
 from paddle_billing.Entities.Discount           import Discount, DiscountStatus
 
 from paddle_billing.Entities.Shared import (
+    AvailablePaymentMethods,
     BillingDetails,
     CollectionMode,
     CurrencyCode,
@@ -528,6 +529,34 @@ class TestTransactionsClient:
         assert discount.updated_at.isoformat() == '2023-08-18T08:51:07.596000+00:00'
         assert isinstance(discount.custom_data, CustomData)
         assert discount.custom_data.data.get('key') == 'value'
+
+
+    def test_get_transaction_returns_transaction_with_available_payment_methods(
+        self,
+        test_client,
+        mock_requests,
+    ):
+        mock_requests.get(
+            f"{test_client.base_url}/transactions/txn_01hen7bxc1p8ep4yk7n5jbzk9r",
+            status_code=200,
+            text=ReadsFixtures.read_raw_json_fixture('response/full_entity'),
+        )
+
+        response = test_client.client.transactions.get('txn_01hen7bxc1p8ep4yk7n5jbzk9r')
+
+        assert isinstance(response, Transaction)
+
+        available_payment_methods = response.available_payment_methods
+        assert available_payment_methods[0] == AvailablePaymentMethods.Alipay
+        assert available_payment_methods[1] == AvailablePaymentMethods.ApplePay
+        assert available_payment_methods[2] == AvailablePaymentMethods.Bancontact
+        assert available_payment_methods[3] == AvailablePaymentMethods.Card
+        assert available_payment_methods[4] == AvailablePaymentMethods.GooglePay
+        assert available_payment_methods[5] == AvailablePaymentMethods.Ideal
+        assert available_payment_methods[6] == AvailablePaymentMethods.Offline
+        assert available_payment_methods[7] == AvailablePaymentMethods.Paypal
+        assert available_payment_methods[8] == AvailablePaymentMethods.Unknown
+        assert available_payment_methods[9] == AvailablePaymentMethods.WireTransfer
 
 
     @mark.parametrize(


### PR DESCRIPTION
Alternative to #36 

### Added
- `AvailablePaymentMethods` now supports `offline`, `unknown` and `wire_transfer`