### PR TITLE
fix: Remove receipt_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 ### Removed
 
 - `AvailablePaymentMethods` - replaced by `PaymentMethodType`
+- Removed `receipt_data` from `CreateOneTimeCharge` and `PreviewOneTimeCharge` subscription operations
+- Removed `receipt_data` from `Transaction`
 
 ## 0.2.2 - 2024-09-03
 

--- a/paddle_billing/Entities/Transaction.py
+++ b/paddle_billing/Entities/Transaction.py
@@ -58,7 +58,6 @@ class Transaction(Entity):
     customer:                  Customer                           | None = None
     discount:                  Discount                           | None = None
     available_payment_methods: list[PaymentMethodType]            | None = None
-    receipt_data:              str                                | None = None
 
 
     @staticmethod
@@ -76,7 +75,6 @@ class Transaction(Entity):
             invoice_id      = data.get('invoice_id'),
             invoice_number  = data.get('invoice_number'),
             origin          = TransactionOrigin(data['origin']),
-            receipt_data    = data.get('receipt_data'),
             status          = TransactionStatus(data['status']),
             subscription_id = data.get('subscription_id'),
             updated_at      = datetime.fromisoformat(data['updated_at']),

--- a/paddle_billing/Notifications/Entities/Transaction.py
+++ b/paddle_billing/Notifications/Entities/Transaction.py
@@ -43,7 +43,6 @@ class Transaction(Entity):
     created_at:                datetime
     updated_at:                datetime
     billed_at:                 datetime | None
-    receipt_data:              str      | None = None
 
 
     @staticmethod
@@ -61,7 +60,6 @@ class Transaction(Entity):
             invoice_id      = data.get('invoice_id'),
             invoice_number  = data.get('invoice_number'),
             origin          = TransactionOrigin(data['origin']),
-            receipt_data    = data.get('receipt_data'),
             status          = TransactionStatus(data['status']),
             subscription_id = data.get('subscription_id'),
             updated_at      = datetime.fromisoformat(data['updated_at']),

--- a/paddle_billing/Resources/Subscriptions/Operations/CreateOneTimeCharge.py
+++ b/paddle_billing/Resources/Subscriptions/Operations/CreateOneTimeCharge.py
@@ -15,7 +15,6 @@ class CreateOneTimeCharge:
     effective_from:     SubscriptionEffectiveFrom
     items:              list[SubscriptionItems | SubscriptionItemsWithPrice]
     on_payment_failure: SubscriptionOnPaymentFailure | Undefined = Undefined()
-    receipt_data:       str                          | Undefined = Undefined()
 
 
     def get_parameters(self) -> dict:

--- a/paddle_billing/Resources/Subscriptions/Operations/PreviewOneTimeCharge.py
+++ b/paddle_billing/Resources/Subscriptions/Operations/PreviewOneTimeCharge.py
@@ -15,7 +15,6 @@ class PreviewOneTimeCharge:
     effective_from:     SubscriptionEffectiveFrom
     items:              list[SubscriptionItems | SubscriptionItemsWithPrice]
     on_payment_failure: SubscriptionOnPaymentFailure | Undefined = Undefined()
-    receipt_data:       str                          | Undefined = Undefined()
 
 
     def get_parameters(self) -> dict:


### PR DESCRIPTION
### Removed

- Removed `receipt_data` from `CreateOneTimeCharge` and `PreviewOneTimeCharge` subscription operations
- Removed `receipt_data` from `Transaction`