### PR TITLE
feat: Add SubscriptionCreated notification entity with transaction_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
   - New shared `TimePeriod` was added (with properties `starts_at` and `ends_at`)
 - Replaced `AdjustmentTimePeriod`, `SubscriptionTimePeriod` and `TransactionTimePeriod` with shared `TimePeriod`
 - Replaced `AdjustmentProration`, `SubscriptionProration` and `TransactionProration` with shared `Proration`
+- `paddle_billing.Entities.Event` `data` will now be `paddle_billing.Notifications.Entities.SubscriptionCreated` for `subscription.created` events
 
 ### Fixed
 

--- a/paddle_billing/Entities/Event.py
+++ b/paddle_billing/Entities/Event.py
@@ -22,9 +22,8 @@ class Event(Entity, ABC):
 
     @staticmethod
     def from_dict(data: dict) -> Event:
-        _type = data['event_type'].split('.')[0] or ''
+        entity_class_name = Event._resolve_event_class_name(data['event_type'])
 
-        entity_class_name  = data['event_type'].split('.')[0].lower().title()
         entity_class       = None
         instantiated_class = None
         entity_module_path = 'paddle_billing.Notifications.Entities'
@@ -41,7 +40,7 @@ class Event(Entity, ABC):
         if not entity_class:
             raise ValueError(f"Event type '{entity_class_name}' cannot be mapped to an object")
         if not issubclass(entity_class, NotificationEntity):
-            raise ValueError(f"Event type '{_type}' is not of NotificationEntity")
+            raise ValueError(f"Event type '{entity_class_name}' is not of NotificationEntity")
 
         return Event(
             data['event_id'],
@@ -49,3 +48,13 @@ class Event(Entity, ABC):
             datetime.fromisoformat(data['occurred_at']),
             instantiated_class.from_dict(data['data']),
         )
+
+
+    @staticmethod
+    def _resolve_event_class_name(event_type) -> str:
+        if event_type == 'subscription.created':
+            return 'SubscriptionCreated'
+
+        event_entity = event_type.split('.')[0] or ''
+
+        return event_entity.lower().title()

--- a/paddle_billing/Notifications/Entities/SubscriptionCreated.py
+++ b/paddle_billing/Notifications/Entities/SubscriptionCreated.py
@@ -21,7 +21,7 @@ from paddle_billing.Notifications.Entities.Subscriptions import (
 
 
 @dataclass
-class Subscription(Entity):
+class SubscriptionCreated(Entity):
     address_id:             str
     billing_cycle:          Duration
     collection_mode:        CollectionMode
@@ -44,12 +44,14 @@ class Subscription(Entity):
     paused_at:              datetime                    | None = None
     scheduled_change:       SubscriptionScheduledChange | None = None
     started_at:             datetime                    | None = None
+    transaction_id:         str                         | None = None
 
 
     @staticmethod
-    def from_dict(data: dict) -> Subscription:
-        return Subscription(
+    def from_dict(data: dict) -> SubscriptionCreated:
+        return SubscriptionCreated(
             id                     = data['id'],
+            transaction_id         = data.get('transaction_id'),
             status                 = SubscriptionStatus(data['status']),
             customer_id            = data['customer_id'],
             address_id             = data['address_id'],

--- a/tests/Functional/Resources/Events/test_EventsClient.py
+++ b/tests/Functional/Resources/Events/test_EventsClient.py
@@ -7,6 +7,9 @@ from paddle_billing.Entities.Collections import EventCollection
 from paddle_billing.Resources.Events.Operations import ListEvents
 from paddle_billing.Resources.Shared.Operations import Pager
 
+from paddle_billing.Notifications.Entities.Subscription        import Subscription
+from paddle_billing.Notifications.Entities.SubscriptionCreated import SubscriptionCreated
+
 from tests.Utils.TestClient   import mock_requests, test_client
 from tests.Utils.ReadsFixture import ReadsFixtures
 
@@ -62,3 +65,27 @@ class TestEventsClient:
             "The URL does not match the expected URL, verify the query string is correct"
         assert response_json == loads(str(expected_response_body)), \
             "The response JSON doesn't match the expected fixture JSON"
+
+
+    def test_list_subscription_created_event(
+        self,
+        test_client,
+        mock_requests,
+    ):
+        mock_requests.get(
+            f"{test_client.base_url}/events",
+            status_code=200,
+            text=ReadsFixtures.read_raw_json_fixture('response/list_default')
+        )
+
+        events = test_client.client.events.list()
+
+        assert isinstance(events, EventCollection)
+
+        subscription_updated_entity = events.items[0].data
+        assert isinstance(subscription_updated_entity, Subscription)
+        assert not hasattr(subscription_updated_entity, 'transaction_id')
+
+        subscription_created_entity = events.items[1].data
+        assert isinstance(subscription_created_entity, SubscriptionCreated)
+        assert subscription_created_entity.transaction_id == 'txn_01hv975mbh902hcyb7mks5kt0n'


### PR DESCRIPTION
### Changed

- `paddle_billing.Entities.Event` `data` will now be `paddle_billing.Notifications.Entities.SubscriptionCreated` for `subscription.created` events