### PR TITLE
fix: Transaction payments payment_method_id can be string or None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 - `PreviewPrice` operation no longer allows empty `items`
 - `CustomersClient.credit_balances` can now be filtered by `currency_code`
+- Transaction payments `payment_method_id` can be `string` or `None`
 
 ### Removed
 

--- a/paddle_billing/Entities/Shared/TransactionPaymentAttempt.py
+++ b/paddle_billing/Entities/Shared/TransactionPaymentAttempt.py
@@ -10,7 +10,7 @@ from paddle_billing.Entities.Shared.PaymentAttemptStatus import PaymentAttemptSt
 @dataclass
 class TransactionPaymentAttempt:
     payment_attempt_id:       str
-    payment_method_id:        str
+    payment_method_id:        str | None
     stored_payment_method_id: str
     amount:                   str
     status:                   PaymentAttemptStatus
@@ -24,7 +24,7 @@ class TransactionPaymentAttempt:
     def from_dict(data: dict) -> TransactionPaymentAttempt:
         return TransactionPaymentAttempt(
             payment_attempt_id       = data['payment_attempt_id'],
-            payment_method_id        = data['payment_method_id'],
+            payment_method_id        = data.get('payment_method_id'),
             stored_payment_method_id = data['stored_payment_method_id'],
             amount                   = data['amount'],
             status                   = PaymentAttemptStatus(data['status']),

--- a/tests/Functional/Resources/Events/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Events/_fixtures/response/list_default.json
@@ -2545,6 +2545,26 @@
             "payment_attempt_id": "0bec49bd-dd4d-45e3-a91e-46992b09c5e2",
             "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
             "stored_payment_method_id": "8009a718-30f7-4718-a7f6-4d3fdecf559b"
+          },
+          {
+            "amount": "66000",
+            "status": "captured",
+            "created_at": "2023-11-23T15:33:02.177841Z",
+            "error_code": null,
+            "captured_at": "2023-11-23T15:33:04.574587Z",
+            "method_details": {
+              "card": {
+                "type": "visa",
+                "last4": "4242",
+                "expiry_year": 2024,
+                "expiry_month": 1,
+                "cardholder_name": "Michael McGovern"
+              },
+              "type": "card"
+            },
+            "payment_attempt_id": "0bec49bd-dd4d-45e3-a91e-46992b09c5e2",
+            "payment_method_id": null,
+            "stored_payment_method_id": "8009a718-30f7-4718-a7f6-4d3fdecf559b"
           }
         ],
         "checkout": {

--- a/tests/Functional/Resources/Events/test_EventsClient.py
+++ b/tests/Functional/Resources/Events/test_EventsClient.py
@@ -9,6 +9,7 @@ from paddle_billing.Resources.Shared.Operations import Pager
 
 from paddle_billing.Notifications.Entities.Subscription        import Subscription
 from paddle_billing.Notifications.Entities.SubscriptionCreated import SubscriptionCreated
+from paddle_billing.Notifications.Entities.Transaction         import Transaction
 
 from tests.Utils.TestClient   import mock_requests, test_client
 from tests.Utils.ReadsFixture import ReadsFixtures
@@ -89,3 +90,29 @@ class TestEventsClient:
         subscription_created_entity = events.items[1].data
         assert isinstance(subscription_created_entity, SubscriptionCreated)
         assert subscription_created_entity.transaction_id == 'txn_01hv975mbh902hcyb7mks5kt0n'
+
+
+    def test_list_transaction_event_with_and_without_payment_method_id(
+        self,
+        test_client,
+        mock_requests,
+    ):
+        mock_requests.get(
+            f"{test_client.base_url}/events",
+            status_code=200,
+            text=ReadsFixtures.read_raw_json_fixture('response/list_default')
+        )
+
+        events = test_client.client.events.list()
+
+        assert isinstance(events, EventCollection)
+
+        transaction_updated_entity = events.items[9].data
+
+        assert isinstance(transaction_updated_entity, Transaction)
+
+        payment_with_payment_method_id = transaction_updated_entity.payments[0]
+        assert payment_with_payment_method_id.payment_method_id == 'paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1'
+
+        payment_without_payment_method_id = transaction_updated_entity.payments[1]
+        assert payment_without_payment_method_id.payment_method_id is None

--- a/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
@@ -159,7 +159,48 @@
         }
       ]
     },
-    "payments": [],
+    "payments": [
+      {
+        "payment_attempt_id": "1f8e8302-b6fa-4290-b457-4c201eb3d53f",
+        "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
+        "stored_payment_method_id": "5f85a637-efa7-4c6b-88ec-9cc05301bb48",
+        "amount": "40000",
+        "status": "captured",
+        "error_code": null,
+        "method_details": {
+          "type": "card",
+          "card": {
+            "type": "visa",
+            "last4": "4242",
+            "expiry_month": 1,
+            "expiry_year": 2024,
+            "cardholder_name": "Joe Bloggs"
+          }
+        },
+        "created_at": "2023-08-18T21:13:07.18821Z",
+        "captured_at": "2023-08-18T21:13:09.477933Z"
+      },
+      {
+        "payment_attempt_id": "1f8e8302-b6fa-4290-b457-4c201eb3d53f",
+        "payment_method_id": null,
+        "stored_payment_method_id": "5f85a637-efa7-4c6b-88ec-9cc05301bb48",
+        "amount": "40000",
+        "status": "captured",
+        "error_code": null,
+        "method_details": {
+          "type": "card",
+          "card": {
+            "type": "visa",
+            "last4": "4242",
+            "expiry_month": 1,
+            "expiry_year": 2024,
+            "cardholder_name": "Joe Bloggs"
+          }
+        },
+        "created_at": "2023-08-18T21:13:07.18821Z",
+        "captured_at": "2023-08-18T21:13:09.477933Z"
+      }
+    ],
     "checkout": {
       "url": "https://magnificent-entremet-7ae0c6.netlify.app/default/overlay?_ptxn=txn_01hen7bxc1p8ep4yk7n5jbzk9r"
     },

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
@@ -967,6 +967,26 @@
           },
           "created_at": "2023-08-18T21:13:07.18821Z",
           "captured_at": "2023-08-18T21:13:09.477933Z"
+        },
+        {
+          "payment_attempt_id": "1f8e8302-b6fa-4290-b457-4c201eb3d53f",
+          "payment_method_id": null,
+          "stored_payment_method_id": "5f85a637-efa7-4c6b-88ec-9cc05301bb48",
+          "amount": "40000",
+          "status": "captured",
+          "error_code": null,
+          "method_details": {
+            "type": "card",
+            "card": {
+              "type": "visa",
+              "last4": "4242",
+              "expiry_month": 1,
+              "expiry_year": 2024,
+              "cardholder_name": "Joe Bloggs"
+            }
+          },
+          "created_at": "2023-08-18T21:13:07.18821Z",
+          "captured_at": "2023-08-18T21:13:09.477933Z"
         }
       ],
       "checkout": {

--- a/tests/Functional/Resources/Transactions/test_TransactionsClient.py
+++ b/tests/Functional/Resources/Transactions/test_TransactionsClient.py
@@ -566,6 +566,28 @@ class TestTransactionsClient:
         assert available_payment_methods[9] == PaymentMethodType.WireTransfer
 
 
+    def test_get_transaction_with_and_without_payment_method_id(
+        self,
+        test_client,
+        mock_requests,
+    ):
+        mock_requests.get(
+            f"{test_client.base_url}/transactions/txn_01hen7bxc1p8ep4yk7n5jbzk9r",
+            status_code=200,
+            text=ReadsFixtures.read_raw_json_fixture('response/full_entity'),
+        )
+
+        response = test_client.client.transactions.get('txn_01hen7bxc1p8ep4yk7n5jbzk9r')
+
+        assert isinstance(response, Transaction)
+
+        payment_with_payment_method_id = response.payments[0]
+        assert payment_with_payment_method_id.payment_method_id == 'paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1'
+
+        payment_without_payment_method_id = response.payments[1]
+        assert payment_without_payment_method_id.payment_method_id is None
+
+
     @mark.parametrize(
         'operation, expected_request_body, expected_response_status, expected_response_body, expected_url',
         [


### PR DESCRIPTION
### Fixed
- Transaction payments `payment_method_id` can be `string` or `None`