### PR TITLE
docs(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## 0.3.0 - 2024-10-08
+## 0.3.0 - 2024-10-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [Unreleased]
+## 0.3.0 - 2024-10-08
 
 ### Added
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,13 +4,13 @@ All breaking changes prior to v1 will be documented in this file to assist with 
 
 ## v0.3.0
 
-### 1. `paddle_billing.Entities.Shared.AvailablePaymentMethods` has been replaced by `paddle_billing.Entities.Shared.PaymentMethodType`.
+### 1. `AvailablePaymentMethods` has been replaced by `PaymentMethodType`.
 
-`Transaction` `available_payment_methods` will now return a list of `PaymentMethodType`.
+`Transaction` `available_payment_methods` will now return a list of `paddle_billing.Entities.Shared.PaymentMethodType`.
 
-All usage of `AvailablePaymentMethods` will need to be replaced with `PaymentMethodType`.
+All usage of `paddle_billing.Entities.Shared.AvailablePaymentMethods` will need to be replaced with `paddle_billing.Entities.Shared.PaymentMethodType`.
 
-### 2. `paddle_billing.Entities.Shared.TimePeriod` has been aligned to API specification
+### 2. `TimePeriod` has been aligned to API specification
 
 Existing shared `TimePeriod` was renamed to `Duration` (with properties `interval` and `frequency`), and new `TimePeriod` was added (with properties `starts_at` and `ends_at`).
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version="0.2.2",
+    version="0.3.0",
     author="Paddle and contributors",
     author_email="team-dx@paddle.com",
     description="Paddle's Python SDK for Paddle Billing",


### PR DESCRIPTION
## Changelog

### Added

- Added `product` to `subscription.items[]`, see [related changelog](https://developer.paddle.com/changelog/2024/subscription-items-product?utm_source=dx&utm_medium=paddle-python-sdk)
- Support custom prices when updating and previewing subscriptions, see [related changelog](https://developer.paddle.com/changelog/2024/add-custom-items-subscription)
- Support for `custom_data` on discounts
- Support notification settings pagination, see [related changelog](https://developer.paddle.com/changelog/2024/notification-settings-pagination)
- Support notification settings `active` filter
- `TransactionsClient.get_invoice_pdf` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)
- `SubscriptionClient` `preview_update` and `preview_one_time_charge` responses now have `import_meta` property
- Support for `tax_rates_used` on Adjustments
- Added `IPAddressesClient.get_ip_addresses` to support retrieval of Paddle IP addresses
- Support for `proration` on subscription `recurring_transaction_details.line_items[]` and `next_transaction.details.line_items[]`
- Added `AdjustmentsClient.get_credit_note`, see [related changelog](https://developer.paddle.com/changelog/2024/generate-adjustments-credit-notes)

### Changed

- `paddle_billing.Entities.Shared.CustomData` is no longer a `dataclass`
- `NotificationSettingsClient.delete` now returns `None` for `204 No Content` response
- `TimePeriod` is now aligned to API specification:
  - Existing shared `TimePeriod` was renamed to `Duration` (with properties `interval` and `frequency`)
  - New shared `TimePeriod` was added (with properties `starts_at` and `ends_at`)
- Replaced `AdjustmentTimePeriod`, `SubscriptionTimePeriod` and `TransactionTimePeriod` with shared `TimePeriod`
- Replaced `AdjustmentProration`, `SubscriptionProration` and `TransactionProration` with shared `Proration`
- `paddle_billing.Entities.Event` `data` will now be `paddle_billing.Notifications.Entities.SubscriptionCreated` for `subscription.created` events
- `paddle_billing.Entities.Event` `data` will now be `paddle_billing.Notifications.Entities.UndefinedEntity` for unknown event types
- `paddle_billing.Resources.Reports.Operations.CreateReport` is replaced by report specific operations `CreateAdjustmentsReport` | `CreateDiscountsReport` | `CreateProductsAndPricesReport` | `CreateTransactionsReport`
- `paddle_billing.Entities.Notification` `payload` is now `paddle_billing.Entities.Notifications.NotificationEvent`
- `paddle_billing.Entities.Shared.BillingDetails` is no longer used for `billing_details` in request operations
  - `CreateTransaction` now uses `paddle_billing.Resources.Transactions.Operations.Create.CreateBillingDetails`
  - `UpdateTransaction` now uses `paddle_billing.Resources.Transactions.Operations.Update.UpdateBillingDetails`
  - `UpdateSubscription` | `PreviewUpdateSubscription` now uses `paddle_billing.Resources.Subscriptions.Operations.Update.UpdateBillingDetails`

### Fixed

- `PreviewPrice` operation no longer allows empty `items`
- `CustomersClient.credit_balances` can now be filtered by `currency_code`
- Transaction payments `payment_method_id` can be `string` or `None`
- `paddle_billing.Notifications.Verifier` `verify()` now expects `request` to be `paddle_billing.Notifications.Requests.Request` protocol
- Client connection errors will be raised as `requests.exceptions.ConnectionError` instead of an `AttributeError`

### Removed

- `AvailablePaymentMethods` - replaced by `PaymentMethodType`
- Removed `receipt_data` from `CreateOneTimeCharge` and `PreviewOneTimeCharge` subscription operations
- Removed `receipt_data` from `Transaction`
- Removed `paddle_billing.Resources.Transactions.Operations.PreviewTransaction` - replaced by `PreviewTransactionByAddress` | `PreviewTransactionByCustomer` | `PreviewTransactionByIP`

---

https://github.com/PaddleHQ/paddle-python-sdk/compare/v0.2.2...main

---

## Upgrade Notes

### 1. `AvailablePaymentMethods` has been replaced by `PaymentMethodType`.

`Transaction` `available_payment_methods` will now return a list of `paddle_billing.Entities.Shared.PaymentMethodType`.

All usage of `paddle_billing.Entities.Shared.AvailablePaymentMethods` will need to be replaced with `paddle_billing.Entities.Shared.PaymentMethodType`.

### 2. `TimePeriod` has been aligned to API specification

Existing shared `TimePeriod` was renamed to `Duration` (with properties `interval` and `frequency`), and new `TimePeriod` was added (with properties `starts_at` and `ends_at`).

Existing usages of `paddle_billing.Entities.Shared.TimePeriod` will need to be changed to `paddle_billing.Entities.Shared.Duration`.

`paddle_billing.Entities.Shared.TimePeriod` should be used in place of:
- `paddle_billing.Entities.Shared.AdjustmentTimePeriod`
- `paddle_billing.Entities.Subscriptions.SubscriptionTimePeriod`
- `paddle_billing.Entities.Transactions.TransactionTimePeriod`

`paddle_billing.Notifications.Entities.Shared.TimePeriod` should be used in place of:
- `paddle_billing.Notifications.Entities.Shared.AdjustmentTimePeriod`
- `paddle_billing.Notifications.Entities.Subscriptions.SubscriptionTimePeriod`
- `paddle_billing.Notifications.Entities.Transactions.TransactionTimePeriod`

`paddle_billing.Entities.Shared.Proration` should be used in place of:
- `paddle_billing.Entities.Shared.AdjustmentProration`
- `paddle_billing.Entities.Subscriptions.SubscriptionProration`
- `paddle_billing.Entities.Transactions.TransactionProration`

`paddle_billing.Notifications.Entities.Shared.Proration` should be used in place of:
- `paddle_billing.Notifications.Entities.Shared.AdjustmentProration`
- `paddle_billing.Notifications.Entities.Transactions.TransactionProration`

### 3. Transaction preview operation `PreviewTransaction` is removed

Usage of `paddle_billing.Resources.Transactions.Operations.PreviewTransaction` should be replaced with one of:
- `paddle_billing.Resources.Transactions.Operations.PreviewTransactionByAddress`
- `paddle_billing.Resources.Transactions.Operations.PreviewTransactionByCustomer`
- `paddle_billing.Resources.Transactions.Operations.PreviewTransactionByIP`

### 4. `CreateReport` operation is replaced by report specific operations `CreateAdjustmentsReport` | `CreateDiscountsReport` | `CreateProductsAndPricesReport` | `CreateTransactionsReport`

Usage of `paddle_billing.Resources.Reports.Operations.CreateReport` should be replaced with one of:
- `paddle_billing.Resources.Reports.Operations.CreateAdjustmentsReport`
- `paddle_billing.Resources.Reports.Operations.CreateDiscountsReport`
- `paddle_billing.Resources.Reports.Operations.CreateProductsAndPricesReport`
- `paddle_billing.Resources.Reports.Operations.CreateTransactionsReport`

### 5. `BillingDetails` entity is no longer used for `billing_details` in request operations

Usage of `paddle_billing.Entities.Shared.BillingDetails` for `billing_details` in request operations, should be replaced with:
- `paddle_billing.Resources.Transactions.Operations.Create.CreateBillingDetails` for `CreateTransaction`
- `paddle_billing.Resources.Transactions.Operations.Update.UpdateBillingDetails` for `UpdateTransaction`
- `paddle_billing.Resources.Subscriptions.Operations.Update.UpdateBillingDetails` for `UpdateSubscription` | `PreviewUpdateSubscription`