### PR TITLE
fix: Handle connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - `CustomersClient.credit_balances` can now be filtered by `currency_code`
 - Transaction payments `payment_method_id` can be `string` or `None`
 - `paddle_billing.Notifications.Verifier` `verify()` now expects `request` to be `paddle_billing.Notifications.Requests.Request` protocol
+- Client connection errors will be raised as `requests.exceptions.ConnectionError` instead of an `AttributeError`
 
 ### Removed
 

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -137,10 +137,9 @@ class Client:
 
             return response
         except RequestException as e:
-            self.status_code = e.response.status_code
-
             api_error = None
             if e.response is not None:
+                self.status_code = e.response.status_code
                 response_parser = ResponseParser(e.response)
                 api_error = response_parser.get_error()
 

--- a/tests/Functional/Client/test_Client.py
+++ b/tests/Functional/Client/test_Client.py
@@ -1,6 +1,7 @@
 from json import loads, dumps
 from pytest import mark, raises
 from urllib.parse import unquote
+import requests
 
 from paddle_billing.Exceptions.ApiError import ApiError
 from paddle_billing.Exceptions.ApiErrors.AddressApiError import AddressApiError
@@ -155,3 +156,16 @@ class TestClient:
         test_client.client.post_raw(expected_request_url)
 
         assert mock_requests.last_request.timeout == 60.0
+
+    def test_client_throws_connection_error(self, test_client, mock_requests):
+        expected_request_url = f"{test_client.base_url}/some/url"
+
+        mock_requests.post(expected_request_url, exc=requests.exceptions.ConnectionError("Some Connection Error"))
+
+        with raises(requests.exceptions.ConnectionError) as exception_info:
+            test_client.client.post_raw(expected_request_url)
+
+        exception = exception_info.value
+
+        assert isinstance(exception, RequestException)
+        assert str(exception) == "Some Connection Error"


### PR DESCRIPTION
### Fixed
- Client connection errors will be raised as `requests.exceptions.ConnectionError` instead of an `AttributeError`
  #54 
