### PR TITLE
fix: Support null proration on transaction line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 0.3.2 - 2024-11-07
+
+### Fixed
+
+- `paddle_billing.Entities.Shared.TransactionLineItemPreview` `proration` can now be None
+
 ## 0.3.1 - 2024-10-14
 
 ### Fixed

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -206,7 +206,7 @@ class Client:
                 "Authorization": f"Bearer {self.__api_key}",
                 "Content-Type": "application/json",
                 "Paddle-Version": str(self.use_api_version),
-                "User-Agent": "PaddleSDK/python 0.2.2",
+                "User-Agent": "PaddleSDK/python 0.3.2",
             }
         )
 

--- a/paddle_billing/Entities/Shared/TransactionLineItemPreview.py
+++ b/paddle_billing/Entities/Shared/TransactionLineItemPreview.py
@@ -15,7 +15,7 @@ class TransactionLineItemPreview:
     unit_totals: UnitTotals
     totals: Totals
     product: Product
-    proration: Proration
+    proration: Proration | None
 
     @staticmethod
     def from_dict(data: dict) -> TransactionLineItemPreview:
@@ -26,5 +26,5 @@ class TransactionLineItemPreview:
             unit_totals=UnitTotals.from_dict(data["unit_totals"]),
             totals=Totals.from_dict(data["totals"]),
             product=Product.from_dict(data["product"]),
-            proration=Proration.from_dict(data["proration"]),
+            proration=Proration.from_dict(data["proration"]) if data.get("proration") else None,
         )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version="0.3.1",
+    version="0.3.2",
     author="Paddle and contributors",
     author_email="team-dx@paddle.com",
     description="Paddle's Python SDK for Paddle Billing",

--- a/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
@@ -130,13 +130,7 @@
             "discount": "3000",
             "total": "27000"
           },
-          "proration": {
-            "rate": "0",
-            "billing_period": {
-              "starts_at": "2023-08-21T11:31:08.689295Z",
-              "ends_at": "2023-09-21T11:31:08.689295Z"
-            }
-          }
+          "proration": null
         },
         {
           "price_id": "pri_01gsz98e27ak2tyhexptwc58yk",
@@ -164,13 +158,6 @@
             "tax": "0",
             "discount": "1990",
             "total": "17910"
-          },
-          "proration": {
-            "rate": "0",
-            "billing_period": {
-              "starts_at": "2023-08-21T11:31:08.689295Z",
-              "ends_at": "2023-09-21T11:31:08.689295Z"
-            }
           }
         }
       ]


### PR DESCRIPTION
### Fixed
- `paddle_billing.Entities.Shared.TransactionLineItemPreview` `proration` can now be None
  - Note: `TransactionLineItemPreview` is used in a few places where `proration` varies (nullable / omitted). In the next major version we should create separate line item classes for each case.