### PR TITLE
docs(release): 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## 1.0.0 - 2024-11-08
+## 1.0.0 - 2024-11-11
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [Unreleased]
+## 1.0.0 - 2024-11-08
 
 ### Changed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,7 +2,7 @@
 
 All breaking changes prior to v1 will be documented in this file to assist with upgrading.
 
-## Unreleased
+## v1.0.0
 
 ### 1. Unused `get_parameters()` method was removed from request operation classes
 

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -200,7 +200,7 @@ class Client:
                 "Authorization": f"Bearer {self.__api_key}",
                 "Content-Type": "application/json",
                 "Paddle-Version": str(self.use_api_version),
-                "User-Agent": "PaddleSDK/python 0.3.2",
+                "User-Agent": "PaddleSDK/python 1.0.0",
             }
         )
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version="0.3.2",
+    version="1.0.0",
     author="Paddle and contributors",
     author_email="team-dx@paddle.com",
     description="Paddle's Python SDK for Paddle Billing",


### PR DESCRIPTION
### Changed

- `paddle_billing.Resources.Discounts.Operations.CreateDiscount` `expires_at` is now `paddle_billing.Entities.DateTime`
- `paddle_billing.Resources.Discounts.Operations.UpdateDiscount` `expires_at` is now `paddle_billing.Entities.DateTime`
- Transaction and Subscription operation items now allow optional properties to be omitted.
  - The following property types have changed (See UPGRADING.md for further details)
    - `paddle_billing.Resources.Subscriptions.Operations`:
      - `UpdateSubscription.items`
      - `PreviewUpdateSubscription.items`
      - `CreateOneTimeCharge.items`
      - `PreviewOneTimeCharge.items`
    - `paddle_billing.Resources.Transactions.Operations`:
      - `CreateTransaction.items`
      - `UpdateTransaction.items`
      - `PreviewTransactionByAddress.items`
      - `PreviewTransactionByCustomer.items`
      - `PreviewTransactionByIP.items`
- Transaction and Subscription preview responses now support preview products and prices without IDs (see UPGRADING.md for further details)

### Removed
- `get_parameters()` method on request operation classes is now removed or replaced by `to_json()` (see UPGRADING.md for further details)