### PR TITLE
feat: API Sync (Nov 2024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - `paddle_billing.Resources.Discounts.Operations.CreateDiscount` `expires_at` is now `paddle_billing.Entities.DateTime`
 - `paddle_billing.Resources.Discounts.Operations.UpdateDiscount` `expires_at` is now `paddle_billing.Entities.DateTime`
 
+### Removed
+- `get_parameters()` method on request operation classes is now removed or replaced by `to_json()` (see UPGRADING.md for further details)
+
 ## 0.3.2 - 2024-11-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [Unreleased]
+
+### Changed
+
+- `paddle_billing.Resources.Discounts.Operations.CreateDiscount` `expires_at` is now `paddle_billing.Entities.DateTime`
+- `paddle_billing.Resources.Discounts.Operations.UpdateDiscount` `expires_at` is now `paddle_billing.Entities.DateTime`
+
 ## 0.3.2 - 2024-11-07
 
 ### Fixed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,66 @@
 
 All breaking changes prior to v1 will be documented in this file to assist with upgrading.
 
+## Unreleased
+
+### 1. Unused `get_parameters()` method was removed from request operation classes
+
+`get_parameters()` methods returned the data used for operation request payloads, but is now removed or replaced by `to_json()`. This method was intended to be internal, so should not require any changes.
+
+`get_parameters()` method was removed from the following classes:
+  - `paddle_billing.Entities.Reports.ReportFilter`
+  - `paddle_billing.Entities.Shared.CustomData`
+  - `paddle_billing.Entities.Subscriptions.SubscriptionItems`
+  - `paddle_billing.Entities.Subscriptions.SubscriptionItemsWithPrice`
+  - `paddle_billing.Notifications.Entities.Reports.ReportFilter`
+  - `paddle_billing.Notifications.Entities.Shared.CustomData`
+  - `paddle_billing.Resources.Addresses.Operations.CreateAddress`
+  - `paddle_billing.Resources.Addresses.Operations.UpdateAddress`
+  - `paddle_billing.Resources.Adjustments.Operations.CreateAdjustment`
+  - `paddle_billing.Resources.Businesses.Operations.CreateBusiness`
+  - `paddle_billing.Resources.Businesses.Operations.UpdateBusiness`
+  - `paddle_billing.Resources.Customers.Operations.CreateCustomer`
+  - `paddle_billing.Resources.Customers.Operations.UpdateCustomer`
+  - `paddle_billing.Resources.Discounts.Operations.CreateDiscount`
+  - `paddle_billing.Resources.Discounts.Operations.UpdateDiscount`
+  - `paddle_billing.Resources.NotificationSettings.Operations.CreateNotificationSetting`
+  - `paddle_billing.Resources.NotificationSettings.Operations.UpdateNotificationSetting`
+  - `paddle_billing.Resources.Prices.Operations.CreatePrice`
+  - `paddle_billing.Resources.Prices.Operations.UpdatePrice`
+  - `paddle_billing.Resources.PricingPreviews.Operations.PreviewPrice`
+  - `paddle_billing.Resources.Products.Operations.CreateProduct`
+  - `paddle_billing.Resources.Products.Operations.UpdateProduct`
+  - `paddle_billing.Resources.Reports.Operations.CreateReport` subclasses:
+    - `paddle_billing.Resources.Reports.Operations.CreateAdjustmentsReport`
+    - `paddle_billing.Resources.Reports.Operations.CreateDiscountsReport`
+    - `paddle_billing.Resources.Reports.Operations.CreateProductsAndPricesReport`
+    - `paddle_billing.Resources.Reports.Operations.CreateTransactionsReport`
+  - `paddle_billing.Resources.Reports.Operations.Filters.Filter` subclasses:
+    - `paddle_billing.Resources.Reports.Operations.Filters.AdjustmentActionFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.AdjustmentStatusFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.CollectionModeFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.CurrencyCodeFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.DiscountStatusFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.DiscountTypeFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.Filter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.PriceStatusFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.PriceTypeFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.PriceUpdatedAtFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.ProductStatusFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.ProductTypeFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.ProductUpdatedAtFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.TransactionOriginFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.TransactionStatusFilter`
+    - `paddle_billing.Resources.Reports.Operations.Filters.UpdatedAtFilter`
+  - `paddle_billing.Resources.Subscriptions.Operations.CancelSubscription`
+  - `paddle_billing.Resources.Subscriptions.Operations.CreateOneTimeCharge`
+  - `paddle_billing.Resources.Subscriptions.Operations.PauseSubscription`
+  - `paddle_billing.Resources.Subscriptions.Operations.PreviewOneTimeCharge`
+  - `paddle_billing.Resources.Subscriptions.Operations.ResumeSubscription`
+  - `paddle_billing.Resources.Transactions.Operations.PreviewTransactionByAddress`
+  - `paddle_billing.Resources.Transactions.Operations.PreviewTransactionByCustomer`
+  - `paddle_billing.Resources.Transactions.Operations.PreviewTransactionByIP`
+
 ## v0.3.0
 
 ### 1. `AvailablePaymentMethods` has been replaced by `PaymentMethodType`.

--- a/paddle_billing/Entities/Reports/ReportFilter.py
+++ b/paddle_billing/Entities/Reports/ReportFilter.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 from paddle_billing.Entities.Reports import ReportFilterName, ReportFilterOperator
 
@@ -13,6 +13,3 @@ class ReportFilter:
     @staticmethod
     def from_dict(data: dict) -> ReportFilter:
         return ReportFilter(**data)
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Entities/Shared/CustomData.py
+++ b/paddle_billing/Entities/Shared/CustomData.py
@@ -4,8 +4,5 @@ class CustomData:
     def __init__(self, data: dict | list):
         self.data = data
 
-    def get_parameters(self):
-        return self.data
-
     def to_json(self):
         return self.data

--- a/paddle_billing/Entities/Subscriptions/SubscriptionItems.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionItems.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 
 @dataclass
@@ -13,6 +13,3 @@ class SubscriptionItems:
             price_id=data["price_id"],
             quantity=data["quantity"],
         )
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Entities/Subscriptions/SubscriptionItemsWithPrice.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionItemsWithPrice.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 from paddle_billing.Entities.Subscriptions.SubscriptionNonCatalogPrice import SubscriptionNonCatalogPrice
 from paddle_billing.Entities.Subscriptions.SubscriptionNonCatalogPriceWithProduct import (
@@ -18,6 +18,3 @@ class SubscriptionItemsWithPrice:
             price=data["price"],
             quantity=data["quantity"],
         )
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Notifications/Entities/Reports/ReportFilter.py
+++ b/paddle_billing/Notifications/Entities/Reports/ReportFilter.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 from paddle_billing.Notifications.Entities.Reports import ReportFilterName, ReportFilterOperator
 
@@ -13,6 +13,3 @@ class ReportFilter:
     @staticmethod
     def from_dict(data: dict) -> ReportFilter:
         return ReportFilter(**data)
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Notifications/Entities/Shared/CustomData.py
+++ b/paddle_billing/Notifications/Entities/Shared/CustomData.py
@@ -5,5 +5,5 @@ from dataclasses import dataclass
 class CustomData:
     data: dict | list  # JSON serializable Python types
 
-    def get_parameters(self):
+    def to_json(self):
         return self.data

--- a/paddle_billing/Resources/Addresses/AddressesClient.py
+++ b/paddle_billing/Resources/Addresses/AddressesClient.py
@@ -35,15 +35,13 @@ class AddressesClient:
         return Address.from_dict(parser.get_data())
 
     def create(self, customer_id: str, operation: CreateAddress) -> Address:
-        self.response = self.client.post_raw(f"/customers/{customer_id}/addresses", operation.get_parameters())
+        self.response = self.client.post_raw(f"/customers/{customer_id}/addresses", operation)
         parser = ResponseParser(self.response)
 
         return Address.from_dict(parser.get_data())
 
     def update(self, customer_id: str, address_id: str, operation: UpdateAddress) -> Address:
-        self.response = self.client.patch_raw(
-            f"/customers/{customer_id}/addresses/{address_id}", operation.get_parameters()
-        )
+        self.response = self.client.patch_raw(f"/customers/{customer_id}/addresses/{address_id}", operation)
         parser = ResponseParser(self.response)
 
         return Address.from_dict(parser.get_data())

--- a/paddle_billing/Resources/Addresses/Operations/CreateAddress.py
+++ b/paddle_billing/Resources/Addresses/Operations/CreateAddress.py
@@ -1,11 +1,12 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import CountryCode, CustomData
 
 
 @dataclass
-class CreateAddress:
+class CreateAddress(Operation):
     country_code: CountryCode
     description: str | None = Undefined()
     first_line: str | None = Undefined()
@@ -14,6 +15,3 @@ class CreateAddress:
     postal_code: str | None = Undefined()
     region: str | None = Undefined()
     custom_data: CustomData | None = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Addresses/Operations/UpdateAddress.py
+++ b/paddle_billing/Resources/Addresses/Operations/UpdateAddress.py
@@ -1,11 +1,12 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import CountryCode, CustomData, Status
 
 
 @dataclass
-class UpdateAddress:
+class UpdateAddress(Operation):
     country_code: CountryCode | Undefined = Undefined()
     description: str | None | Undefined = Undefined()
     first_line: str | None | Undefined = Undefined()
@@ -15,6 +16,3 @@ class UpdateAddress:
     region: str | None | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
     status: Status | None | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Adjustments/AdjustmentsClient.py
+++ b/paddle_billing/Resources/Adjustments/AdjustmentsClient.py
@@ -29,7 +29,7 @@ class AdjustmentsClient:
         )
 
     def create(self, operation: CreateAdjustment) -> Adjustment:
-        self.response = self.client.post_raw("/adjustments", operation.get_parameters())
+        self.response = self.client.post_raw("/adjustments", operation)
         parser = ResponseParser(self.response)
 
         return Adjustment.from_dict(parser.get_data())

--- a/paddle_billing/Resources/Adjustments/Operations/CreateAdjustment.py
+++ b/paddle_billing/Resources/Adjustments/Operations/CreateAdjustment.py
@@ -1,30 +1,15 @@
 from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
+
 from paddle_billing.Entities.Shared import Action
 
 from paddle_billing.Resources.Adjustments.Operations import CreateAdjustmentItem
 
 
 @dataclass
-class CreateAdjustment:
+class CreateAdjustment(Operation):
     action: Action
     items: list[CreateAdjustmentItem]
     reason: str
     transaction_id: str
-
-    def get_parameters(self) -> dict:
-        items = [
-            {
-                "item_id": item.item_id,
-                "type": item.type,
-                "amount": item.amount,
-            }
-            for item in self.items
-        ]
-
-        return {
-            "action": self.action.value,
-            "items": items,
-            "reason": self.reason,
-            "transaction_id": self.transaction_id,
-        }

--- a/paddle_billing/Resources/Businesses/BusinessesClient.py
+++ b/paddle_billing/Resources/Businesses/BusinessesClient.py
@@ -35,15 +35,13 @@ class BusinessesClient:
         return Business.from_dict(parser.get_data())
 
     def create(self, customer_id: str, operation: CreateBusiness) -> Business:
-        self.response = self.client.post_raw(f"/customers/{customer_id}/businesses", operation.get_parameters())
+        self.response = self.client.post_raw(f"/customers/{customer_id}/businesses", operation)
         parser = ResponseParser(self.response)
 
         return Business.from_dict(parser.get_data())
 
     def update(self, customer_id: str, business_id: str, operation: UpdateBusiness) -> Business:
-        self.response = self.client.patch_raw(
-            f"/customers/{customer_id}/businesses/{business_id}", operation.get_parameters()
-        )
+        self.response = self.client.patch_raw(f"/customers/{customer_id}/businesses/{business_id}", operation)
         parser = ResponseParser(self.response)
 
         return Business.from_dict(parser.get_data())

--- a/paddle_billing/Resources/Businesses/Operations/CreateBusiness.py
+++ b/paddle_billing/Resources/Businesses/Operations/CreateBusiness.py
@@ -1,16 +1,14 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import Contacts, CustomData
 
 
 @dataclass
-class CreateBusiness:
+class CreateBusiness(Operation):
     name: str
     company_number: str | None | Undefined = Undefined()
     tax_identifier: str | None | Undefined = Undefined()
     contacts: list[Contacts] | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Businesses/Operations/UpdateBusiness.py
+++ b/paddle_billing/Resources/Businesses/Operations/UpdateBusiness.py
@@ -1,17 +1,15 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import Contacts, CustomData, Status
 
 
 @dataclass
-class UpdateBusiness:
+class UpdateBusiness(Operation):
     name: str | Undefined = Undefined()
     company_number: str | None | Undefined = Undefined()
     tax_identifier: str | None | Undefined = Undefined()
     contacts: list[Contacts] | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
     status: Status | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Customers/CustomersClient.py
+++ b/paddle_billing/Resources/Customers/CustomersClient.py
@@ -40,13 +40,13 @@ class CustomersClient:
         return Customer.from_dict(parser.get_data())
 
     def create(self, operation: CreateCustomer) -> Customer:
-        self.response = self.client.post_raw("/customers", operation.get_parameters())
+        self.response = self.client.post_raw("/customers", operation)
         parser = ResponseParser(self.response)
 
         return Customer.from_dict(parser.get_data())
 
     def update(self, customer_id: str, operation: UpdateCustomer) -> Customer:
-        self.response = self.client.patch_raw(f"/customers/{customer_id}", operation.get_parameters())
+        self.response = self.client.patch_raw(f"/customers/{customer_id}", operation)
         parser = ResponseParser(self.response)
 
         return Customer.from_dict(parser.get_data())

--- a/paddle_billing/Resources/Customers/Operations/CreateCustomer.py
+++ b/paddle_billing/Resources/Customers/Operations/CreateCustomer.py
@@ -1,15 +1,13 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import CustomData
 
 
 @dataclass
-class CreateCustomer:
+class CreateCustomer(Operation):
     email: str
     name: str | None | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
     locale: str | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Customers/Operations/UpdateCustomer.py
+++ b/paddle_billing/Resources/Customers/Operations/UpdateCustomer.py
@@ -1,16 +1,14 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import CustomData, Status
 
 
 @dataclass
-class UpdateCustomer:
+class UpdateCustomer(Operation):
     email: str | Undefined = Undefined()
     name: str | None | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
     locale: str | Undefined = Undefined()
     status: Status | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Discounts/DiscountsClient.py
+++ b/paddle_billing/Resources/Discounts/DiscountsClient.py
@@ -35,13 +35,13 @@ class DiscountsClient:
         return Discount.from_dict(parser.get_data())
 
     def create(self, operation: CreateDiscount) -> Discount:
-        self.response = self.client.post_raw("/discounts", operation.get_parameters())
+        self.response = self.client.post_raw("/discounts", operation)
         parser = ResponseParser(self.response)
 
         return Discount.from_dict(parser.get_data())
 
     def update(self, discount_id: str, operation: UpdateDiscount) -> Discount:
-        self.response = self.client.patch_raw(f"/discounts/{discount_id}", operation.get_parameters())
+        self.response = self.client.patch_raw(f"/discounts/{discount_id}", operation)
         parser = ResponseParser(self.response)
 
         return Discount.from_dict(parser.get_data())

--- a/paddle_billing/Resources/Discounts/Operations/CreateDiscount.py
+++ b/paddle_billing/Resources/Discounts/Operations/CreateDiscount.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.DateTime import DateTime
 from paddle_billing.Entities.Discounts import DiscountType
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Shared import CurrencyCode, CustomData
 
 
 @dataclass
-class CreateDiscount:
+class CreateDiscount(Operation):
     amount: str
     description: str
     type: DiscountType
@@ -20,6 +21,3 @@ class CreateDiscount:
     restrict_to: list[str] | None | Undefined = Undefined()
     expires_at: DateTime | None | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Discounts/Operations/CreateDiscount.py
+++ b/paddle_billing/Resources/Discounts/Operations/CreateDiscount.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict, dataclass
 
 from paddle_billing.Undefined import Undefined
+from paddle_billing.Entities.DateTime import DateTime
 from paddle_billing.Entities.Discounts import DiscountType
 from paddle_billing.Entities.Shared import CurrencyCode, CustomData
 
@@ -17,7 +18,7 @@ class CreateDiscount:
     maximum_recurring_intervals: int | None | Undefined = Undefined()
     usage_limit: int | None | Undefined = Undefined()
     restrict_to: list[str] | None | Undefined = Undefined()
-    expires_at: str | None | Undefined = Undefined()
+    expires_at: DateTime | None | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
 
     def get_parameters(self) -> dict:

--- a/paddle_billing/Resources/Discounts/Operations/UpdateDiscount.py
+++ b/paddle_billing/Resources/Discounts/Operations/UpdateDiscount.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.DateTime import DateTime
 from paddle_billing.Entities.Discounts import DiscountStatus, DiscountType
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Shared import CurrencyCode, CustomData
 
 
 @dataclass
-class UpdateDiscount:
+class UpdateDiscount(Operation):
     amount: str | Undefined = Undefined()
     description: str | Undefined = Undefined()
     type: DiscountType | Undefined = Undefined()
@@ -21,6 +22,3 @@ class UpdateDiscount:
     expires_at: DateTime | None | Undefined = Undefined()
     status: DiscountStatus | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Discounts/Operations/UpdateDiscount.py
+++ b/paddle_billing/Resources/Discounts/Operations/UpdateDiscount.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict, dataclass
 
 from paddle_billing.Undefined import Undefined
+from paddle_billing.Entities.DateTime import DateTime
 from paddle_billing.Entities.Discounts import DiscountStatus, DiscountType
 from paddle_billing.Entities.Shared import CurrencyCode, CustomData
 
@@ -17,7 +18,7 @@ class UpdateDiscount:
     maximum_recurring_intervals: int | None | Undefined = Undefined()
     usage_limit: int | None | Undefined = Undefined()
     restrict_to: list[str] | None | Undefined = Undefined()
-    expires_at: str | None | Undefined = Undefined()
+    expires_at: DateTime | None | Undefined = Undefined()
     status: DiscountStatus | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
 

--- a/paddle_billing/Resources/NotificationSettings/NotificationSettingsClient.py
+++ b/paddle_billing/Resources/NotificationSettings/NotificationSettingsClient.py
@@ -39,15 +39,13 @@ class NotificationSettingsClient:
         return NotificationSetting.from_dict(parser.get_data())
 
     def create(self, operation: CreateNotificationSetting) -> NotificationSetting:
-        self.response = self.client.post_raw("/notification-settings", operation.get_parameters())
+        self.response = self.client.post_raw("/notification-settings", operation)
         parser = ResponseParser(self.response)
 
         return NotificationSetting.from_dict(parser.get_data())
 
     def update(self, notification_setting_id: str, operation: UpdateNotificationSetting) -> NotificationSetting:
-        self.response = self.client.patch_raw(
-            f"/notification-settings/{notification_setting_id}", operation.get_parameters()
-        )
+        self.response = self.client.patch_raw(f"/notification-settings/{notification_setting_id}", operation)
         parser = ResponseParser(self.response)
 
         return NotificationSetting.from_dict(parser.get_data())

--- a/paddle_billing/Resources/NotificationSettings/Operations/CreateNotificationSetting.py
+++ b/paddle_billing/Resources/NotificationSettings/Operations/CreateNotificationSetting.py
@@ -1,18 +1,16 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Events import EventTypeName
 from paddle_billing.Entities.NotificationSettings import NotificationSettingType
 
 
 @dataclass
-class CreateNotificationSetting:
+class CreateNotificationSetting(Operation):
     description: str
     destination: str
     subscribed_events: list[EventTypeName]
     type: NotificationSettingType
     include_sensitive_fields: bool
     api_version: int | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/NotificationSettings/Operations/UpdateNotificationSetting.py
+++ b/paddle_billing/Resources/NotificationSettings/Operations/UpdateNotificationSetting.py
@@ -1,17 +1,15 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Events import EventTypeName
 
 
 @dataclass
-class UpdateNotificationSetting:
+class UpdateNotificationSetting(Operation):
     description: str | Undefined = Undefined()
     destination: str | Undefined = Undefined()
     active: bool | Undefined = Undefined()
     api_version: int | Undefined = Undefined()
     include_sensitive_fields: bool | Undefined = Undefined()
     subscribed_events: list[EventTypeName] | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Prices/Operations/CreatePrice.py
+++ b/paddle_billing/Resources/Prices/Operations/CreatePrice.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import (
     CatalogType,
@@ -13,7 +14,7 @@ from paddle_billing.Entities.Shared import (
 
 
 @dataclass
-class CreatePrice:
+class CreatePrice(Operation):
     description: str
     product_id: str
     unit_price: Money
@@ -25,6 +26,3 @@ class CreatePrice:
     billing_cycle: Duration | None | Undefined = Undefined()
     quantity: PriceQuantity | Undefined = Undefined()
     custom_data: CustomData | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Prices/Operations/UpdatePrice.py
+++ b/paddle_billing/Resources/Prices/Operations/UpdatePrice.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import (
     CatalogType,
@@ -14,7 +15,7 @@ from paddle_billing.Entities.Shared import (
 
 
 @dataclass
-class UpdatePrice:
+class UpdatePrice(Operation):
     description: str | Undefined = Undefined()
     name: str | None | Undefined = Undefined()
     type: CatalogType | Undefined = Undefined()
@@ -26,6 +27,3 @@ class UpdatePrice:
     quantity: PriceQuantity | Undefined = Undefined()
     status: Status | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Prices/PricesClient.py
+++ b/paddle_billing/Resources/Prices/PricesClient.py
@@ -47,13 +47,13 @@ class PricesClient:
         return Price.from_dict(parser.get_data())
 
     def create(self, operation: CreatePrice) -> Price:
-        self.response = self.client.post_raw("/prices", operation.get_parameters())
+        self.response = self.client.post_raw("/prices", operation)
         parser = ResponseParser(self.response)
 
         return Price.from_dict(parser.get_data())
 
     def update(self, price_id: str, operation: UpdatePrice) -> Price:
-        self.response = self.client.patch_raw(f"/prices/{price_id}", operation.get_parameters())
+        self.response = self.client.patch_raw(f"/prices/{price_id}", operation)
         parser = ResponseParser(self.response)
 
         return Price.from_dict(parser.get_data())

--- a/paddle_billing/Resources/PricingPreviews/Operations/PreviewPrice.py
+++ b/paddle_billing/Resources/PricingPreviews/Operations/PreviewPrice.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.PricingPreviews import PricePreviewItem
 from paddle_billing.Entities.Shared import CurrencyCode, AddressPreview
@@ -8,7 +9,7 @@ from paddle_billing.Exceptions.SdkExceptions.InvalidArgumentException import Inv
 
 
 @dataclass
-class PreviewPrice:
+class PreviewPrice(Operation):
     items: list[PricePreviewItem]
     customer_id: str | None | Undefined = Undefined()
     address_id: str | None | Undefined = Undefined()
@@ -28,6 +29,3 @@ class PreviewPrice:
             raise InvalidArgumentException.array_contains_invalid_types(
                 "items", PricePreviewItem.__name__, invalid_items
             )
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/PricingPreviews/PricingPreviewsClient.py
+++ b/paddle_billing/Resources/PricingPreviews/PricingPreviewsClient.py
@@ -14,7 +14,7 @@ class PricingPreviewsClient:
         self.response = None
 
     def preview_prices(self, operation: PreviewPrice) -> PricePreview:
-        self.response = self.client.post_raw("/pricing-preview", operation.get_parameters())
+        self.response = self.client.post_raw("/pricing-preview", operation)
         parser = ResponseParser(self.response)
 
         return PricePreview.from_dict(parser.get_data())

--- a/paddle_billing/Resources/Products/Operations/CreateProduct.py
+++ b/paddle_billing/Resources/Products/Operations/CreateProduct.py
@@ -1,17 +1,15 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import CatalogType, CustomData, TaxCategory
 
 
 @dataclass
-class CreateProduct:
+class CreateProduct(Operation):
     name: str
     tax_category: TaxCategory
     type: CatalogType | None | Undefined = Undefined()
     description: str | None | Undefined = Undefined()
     image_url: str | None | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Products/Operations/UpdateProduct.py
+++ b/paddle_billing/Resources/Products/Operations/UpdateProduct.py
@@ -1,11 +1,12 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import CatalogType, CustomData, Status, TaxCategory
 
 
 @dataclass
-class UpdateProduct:
+class UpdateProduct(Operation):
     name: str | Undefined = Undefined()
     description: str | None | Undefined = Undefined()
     type: CatalogType | None | Undefined = Undefined()
@@ -13,6 +14,3 @@ class UpdateProduct:
     image_url: str | None | Undefined = Undefined()
     custom_data: CustomData | None | Undefined = Undefined()
     status: Status | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Products/ProductsClient.py
+++ b/paddle_billing/Resources/Products/ProductsClient.py
@@ -52,13 +52,13 @@ class ProductsClient:
         return Product.from_dict(parser.get_data())
 
     def create(self, operation: CreateProduct) -> Product:
-        self.response = self.client.post_raw("/products", operation.get_parameters())
+        self.response = self.client.post_raw("/products", operation)
         parser = ResponseParser(self.response)
 
         return Product.from_dict(parser.get_data())
 
     def update(self, product_id: str, operation: UpdateProduct) -> Product:
-        self.response = self.client.patch_raw(f"/products/{product_id}", operation.get_parameters())
+        self.response = self.client.patch_raw(f"/products/{product_id}", operation)
         parser = ResponseParser(self.response)
 
         return Product.from_dict(parser.get_data())

--- a/paddle_billing/Resources/Reports/Operations/CreateReport.py
+++ b/paddle_billing/Resources/Reports/Operations/CreateReport.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass, field
 from abc import ABC, abstractmethod
 
+from paddle_billing.Operation import Operation
+
 from paddle_billing.Entities.Reports import ReportType, ReportFilter
 
 from paddle_billing.Exceptions.SdkExceptions.InvalidArgumentException import InvalidArgumentException
 
 
 @dataclass
-class CreateReport(ABC):
+class CreateReport(Operation, ABC):
     type: ReportType
     filters: list[ReportFilter] = field(default_factory=list)
 
@@ -21,11 +23,11 @@ class CreateReport(ABC):
 
             raise InvalidArgumentException.array_contains_invalid_types("filters", allowed_type_names, invalid_items)
 
-    def get_parameters(self) -> dict:
+    def to_json(self) -> dict:
         parameters = {"type": self.type}
 
         if self.filters is not None and self.filters != []:
-            parameters.update({"filters": [filter_.get_parameters() for filter_ in self.filters]})
+            parameters.update({"filters": [filter_ for filter_ in self.filters]})
 
         return parameters
 

--- a/paddle_billing/Resources/Reports/Operations/Filters/Filter.py
+++ b/paddle_billing/Resources/Reports/Operations/Filters/Filter.py
@@ -9,7 +9,7 @@ from paddle_billing.Entities.Reports import ReportFilterName
 
 @dataclass
 class Filter(ABC):
-    def get_parameters(self) -> dict:
+    def to_json(self) -> dict:
         return {
             "name": self.get_name(),
             "operator": self.get_operator(),

--- a/paddle_billing/Resources/Reports/ReportsClient.py
+++ b/paddle_billing/Resources/Reports/ReportsClient.py
@@ -41,7 +41,7 @@ class ReportsClient:
         return ReportCSV.from_dict(parser.get_data())
 
     def create(self, operation: CreateReport) -> Report:
-        self.response = self.client.post_raw("/reports", operation.get_parameters())
+        self.response = self.client.post_raw("/reports", operation)
         parser = ResponseParser(self.response)
 
         return Report.from_dict(parser.get_data())

--- a/paddle_billing/Resources/Subscriptions/Operations/CancelSubscription.py
+++ b/paddle_billing/Resources/Subscriptions/Operations/CancelSubscription.py
@@ -1,11 +1,9 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Entities.Subscriptions import SubscriptionEffectiveFrom
 
 
 @dataclass
-class CancelSubscription:
+class CancelSubscription(Operation):
     effective_from: SubscriptionEffectiveFrom = None
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Subscriptions/Operations/CreateOneTimeCharge.py
+++ b/paddle_billing/Resources/Subscriptions/Operations/CreateOneTimeCharge.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 
 from paddle_billing.Entities.Subscriptions import (
@@ -11,10 +12,7 @@ from paddle_billing.Entities.Subscriptions import (
 
 
 @dataclass
-class CreateOneTimeCharge:
+class CreateOneTimeCharge(Operation):
     effective_from: SubscriptionEffectiveFrom
     items: list[SubscriptionItems | SubscriptionItemsWithPrice]
     on_payment_failure: SubscriptionOnPaymentFailure | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Subscriptions/Operations/PauseSubscription.py
+++ b/paddle_billing/Resources/Subscriptions/Operations/PauseSubscription.py
@@ -1,16 +1,11 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Entities.DateTime import DateTime
 from paddle_billing.Entities.Subscriptions import SubscriptionEffectiveFrom
 
 
 @dataclass
-class PauseSubscription:
+class PauseSubscription(Operation):
     effective_from: SubscriptionEffectiveFrom | None = None
     resume_at: DateTime | None = None
-
-    def get_parameters(self) -> dict:
-        parameters = asdict(self)
-        parameters["resume_at"] = self.resume_at.format() if isinstance(self.resume_at, DateTime) else self.resume_at
-
-        return parameters

--- a/paddle_billing/Resources/Subscriptions/Operations/PreviewOneTimeCharge.py
+++ b/paddle_billing/Resources/Subscriptions/Operations/PreviewOneTimeCharge.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 
 from paddle_billing.Entities.Subscriptions import (
@@ -11,10 +12,7 @@ from paddle_billing.Entities.Subscriptions import (
 
 
 @dataclass
-class PreviewOneTimeCharge:
+class PreviewOneTimeCharge(Operation):
     effective_from: SubscriptionEffectiveFrom
     items: list[SubscriptionItems | SubscriptionItemsWithPrice]
     on_payment_failure: SubscriptionOnPaymentFailure | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Subscriptions/Operations/ResumeSubscription.py
+++ b/paddle_billing/Resources/Subscriptions/Operations/ResumeSubscription.py
@@ -1,16 +1,10 @@
 from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Entities.DateTime import DateTime
 from paddle_billing.Entities.Subscriptions import SubscriptionResumeEffectiveFrom
 
 
 @dataclass
-class ResumeSubscription:
+class ResumeSubscription(Operation):
     effective_from: SubscriptionResumeEffectiveFrom | DateTime | None = None
-
-    def get_parameters(self) -> dict:
-        effective_from = (
-            self.effective_from.format() if isinstance(self.effective_from, DateTime) else self.effective_from
-        )
-
-        return {"effective_from": effective_from}

--- a/paddle_billing/Resources/Subscriptions/SubscriptionsClient.py
+++ b/paddle_billing/Resources/Subscriptions/SubscriptionsClient.py
@@ -64,19 +64,19 @@ class SubscriptionsClient:
         return Subscription.from_dict(parser.get_data())
 
     def pause(self, subscription_id: str, operation: PauseSubscription) -> Subscription:
-        self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/pause", operation.get_parameters())
+        self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/pause", operation)
         parser = ResponseParser(self.response)
 
         return Subscription.from_dict(parser.get_data())
 
     def resume(self, subscription_id: str, operation: ResumeSubscription) -> Subscription:
-        self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/resume", operation.get_parameters())
+        self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/resume", operation)
         parser = ResponseParser(self.response)
 
         return Subscription.from_dict(parser.get_data())
 
     def cancel(self, subscription_id: str, operation: CancelSubscription) -> Subscription:
-        self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/cancel", operation.get_parameters())
+        self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/cancel", operation)
         parser = ResponseParser(self.response)
 
         return Subscription.from_dict(parser.get_data())
@@ -94,7 +94,7 @@ class SubscriptionsClient:
         return Subscription.from_dict(parser.get_data())
 
     def create_one_time_charge(self, subscription_id: str, operation: CreateOneTimeCharge) -> Subscription:
-        self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/charge", operation.get_parameters())
+        self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/charge", operation)
         parser = ResponseParser(self.response)
 
         return Subscription.from_dict(parser.get_data())
@@ -106,9 +106,7 @@ class SubscriptionsClient:
         return SubscriptionPreview.from_dict(parser.get_data())
 
     def preview_one_time_charge(self, subscription_id: str, operation: PreviewOneTimeCharge) -> SubscriptionPreview:
-        self.response = self.client.post_raw(
-            f"/subscriptions/{subscription_id}/charge/preview", operation.get_parameters()
-        )
+        self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/charge/preview", operation)
         parser = ResponseParser(self.response)
 
         return SubscriptionPreview.from_dict(parser.get_data())

--- a/paddle_billing/Resources/Transactions/Operations/PreviewTransactionByAddress.py
+++ b/paddle_billing/Resources/Transactions/Operations/PreviewTransactionByAddress.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import AddressPreview, CurrencyCode
 from paddle_billing.Entities.Transactions import (
@@ -9,13 +10,10 @@ from paddle_billing.Entities.Transactions import (
 
 
 @dataclass
-class PreviewTransactionByAddress:
+class PreviewTransactionByAddress(Operation):
     address: AddressPreview
     items: list[TransactionItemPreviewWithPriceId | TransactionItemPreviewWithNonCatalogPrice]
     customer_id: str | None | Undefined = Undefined()
     currency_code: CurrencyCode | Undefined = Undefined()
     discount_id: str | None | Undefined = Undefined()
     ignore_trials: bool | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Transactions/Operations/PreviewTransactionByCustomer.py
+++ b/paddle_billing/Resources/Transactions/Operations/PreviewTransactionByCustomer.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import CurrencyCode
 from paddle_billing.Entities.Transactions import (
@@ -9,7 +10,7 @@ from paddle_billing.Entities.Transactions import (
 
 
 @dataclass
-class PreviewTransactionByCustomer:
+class PreviewTransactionByCustomer(Operation):
     address_id: str
     customer_id: str
     items: list[TransactionItemPreviewWithPriceId | TransactionItemPreviewWithNonCatalogPrice]
@@ -17,6 +18,3 @@ class PreviewTransactionByCustomer:
     currency_code: CurrencyCode | Undefined = Undefined()
     discount_id: str | None | Undefined = Undefined()
     ignore_trials: bool | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Transactions/Operations/PreviewTransactionByIP.py
+++ b/paddle_billing/Resources/Transactions/Operations/PreviewTransactionByIP.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
+from paddle_billing.Operation import Operation
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Entities.Shared import CurrencyCode
 from paddle_billing.Entities.Transactions import (
@@ -9,13 +10,10 @@ from paddle_billing.Entities.Transactions import (
 
 
 @dataclass
-class PreviewTransactionByIP:
+class PreviewTransactionByIP(Operation):
     customer_ip_address: str
     items: list[TransactionItemPreviewWithPriceId | TransactionItemPreviewWithNonCatalogPrice]
     customer_id: str | None | Undefined = Undefined()
     currency_code: CurrencyCode | Undefined = Undefined()
     discount_id: str | None | Undefined = Undefined()
     ignore_trials: bool | Undefined = Undefined()
-
-    def get_parameters(self) -> dict:
-        return asdict(self)

--- a/paddle_billing/Resources/Transactions/TransactionsClient.py
+++ b/paddle_billing/Resources/Transactions/TransactionsClient.py
@@ -81,7 +81,7 @@ class TransactionsClient:
     def preview(
         self, operation: PreviewTransactionByAddress | PreviewTransactionByCustomer | PreviewTransactionByIP
     ) -> TransactionPreview:
-        self.response = self.client.post_raw("/transactions/preview", operation.get_parameters())
+        self.response = self.client.post_raw("/transactions/preview", operation)
         parser = ResponseParser(self.response)
 
         return TransactionPreview.from_dict(parser.get_data())

--- a/tests/Functional/Resources/Discounts/_fixtures/request/create_full.json
+++ b/tests/Functional/Resources/Discounts/_fixtures/request/create_full.json
@@ -12,7 +12,7 @@
         "pro_01gsz4t5hdjse780zja8vvr7jg",
         "pro_01gsz4s0w61y0pp88528f1wvvb"
     ],
-    "expires_at": "2025-01-01 10:00:00",
+    "expires_at": "2025-01-01T10:00:00.000000Z",
     "custom_data": {
         "key": "value"
     }

--- a/tests/Functional/Resources/Discounts/_fixtures/request/update_full.json
+++ b/tests/Functional/Resources/Discounts/_fixtures/request/update_full.json
@@ -12,7 +12,7 @@
         "pro_01gsz4t5hdjse780zja8vvr7jg",
         "pro_01gsz4s0w61y0pp88528f1wvvb"
     ],
-    "expires_at": "2025-01-01 10:00:00",
+    "expires_at": "2025-01-01T10:00:00.000000Z",
     "status": "active",
     "custom_data": {
         "key": "value"

--- a/tests/Functional/Resources/Discounts/test_DiscountsClient.py
+++ b/tests/Functional/Resources/Discounts/test_DiscountsClient.py
@@ -3,6 +3,7 @@ from pytest import mark
 from urllib.parse import unquote
 
 from paddle_billing.Entities.Collections import DiscountCollection
+from paddle_billing.Entities.DateTime import DateTime
 from paddle_billing.Entities.Discount import Discount
 from paddle_billing.Entities.Discounts import DiscountStatus, DiscountType
 from paddle_billing.Entities.Shared import CurrencyCode, Status, CustomData
@@ -43,7 +44,7 @@ class TestDiscountsClient:
                     maximum_recurring_intervals=5,
                     usage_limit=1000,
                     restrict_to=["pro_01gsz4t5hdjse780zja8vvr7jg", "pro_01gsz4s0w61y0pp88528f1wvvb"],
-                    expires_at="2025-01-01 10:00:00",
+                    expires_at=DateTime("2025-01-01 10:00:00"),
                     custom_data=CustomData({"key": "value"}),
                 ),
                 ReadsFixtures.read_raw_json_fixture("request/create_full"),
@@ -144,7 +145,7 @@ class TestDiscountsClient:
                     code="ABCDE12345",
                     maximum_recurring_intervals=5,
                     usage_limit=1000,
-                    expires_at="2025-01-01 10:00:00",
+                    expires_at=DateTime("2025-01-01 10:00:00"),
                     status=DiscountStatus.Active,
                     restrict_to=[
                         "pro_01gsz4t5hdjse780zja8vvr7jg",


### PR DESCRIPTION
### Changed

- `paddle_billing.Resources.Discounts.Operations.CreateDiscount` `expires_at` is now `paddle_billing.Entities.DateTime`
- `paddle_billing.Resources.Discounts.Operations.UpdateDiscount` `expires_at` is now `paddle_billing.Entities.DateTime`

### Removed
- `get_parameters()` method on request operation classes is now removed or replaced by `to_json()` (see UPGRADING.md for further details)
