### PR TITLE
fix: PaymentMethod type property is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.1.1 - 2024-11-14
+
+### Fixed
+
+- `paddle_billing.Entities.PaymentMethod` `type` property is required
+
 ## 1.1.0 - 2024-11-14
 
 ### Added

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -202,7 +202,7 @@ class Client:
                 "Authorization": f"Bearer {self.__api_key}",
                 "Content-Type": "application/json",
                 "Paddle-Version": str(self.use_api_version),
-                "User-Agent": "PaddleSDK/python 1.1.0",
+                "User-Agent": "PaddleSDK/python 1.1.1",
             }
         )
 

--- a/paddle_billing/Entities/PaymentMethod.py
+++ b/paddle_billing/Entities/PaymentMethod.py
@@ -16,7 +16,7 @@ class PaymentMethod(Entity):
     id: str
     customer_id: str
     address_id: str
-    type: SavedPaymentMethodType | None
+    type: SavedPaymentMethodType
     card: Card | None
     paypal: Paypal | None
     origin: SavedPaymentMethodOrigin

--- a/paddle_billing/Notifications/Entities/PaymentMethod.py
+++ b/paddle_billing/Notifications/Entities/PaymentMethod.py
@@ -14,7 +14,7 @@ class PaymentMethod(Entity):
     id: str
     customer_id: str
     address_id: str
-    type: SavedPaymentMethodType | None
+    type: SavedPaymentMethodType
     origin: SavedPaymentMethodOrigin
     saved_at: datetime
     updated_at: datetime

--- a/paddle_billing/Notifications/Entities/PaymentMethodDeleted.py
+++ b/paddle_billing/Notifications/Entities/PaymentMethodDeleted.py
@@ -15,7 +15,7 @@ class PaymentMethodDeleted(Entity):
     id: str
     customer_id: str
     address_id: str
-    type: SavedPaymentMethodType | None
+    type: SavedPaymentMethodType
     origin: SavedPaymentMethodOrigin
     saved_at: datetime
     updated_at: datetime

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version="1.1.0",
+    version="1.1.1",
     author="Paddle and contributors",
     author_email="team-dx@paddle.com",
     description="Paddle's Python SDK for Paddle Billing",


### PR DESCRIPTION
### Fixed

- `paddle_billing.Entities.PaymentMethod` `type` property is required