### PR TITLE
fix: Subscription notification should always return billing period when set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [Unreleased]
+## 1.1.2 - 2024-11-20
 
-### Added
-- Added `traffic_source` property to `paddle_billing.Entities.NotificationSetting` entity
+### Fixed
+- `paddle_billing.Notifications.Entities.Subscription` and `paddle_billing.Notifications.Entities.SubscriptionCreated` `current_billing_period` would return `None` if `billing_details` was `None`. `current_billing_period` will now return `TimePeriod` when set.
 
 ## 1.1.1 - 2024-11-14
 

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -202,7 +202,7 @@ class Client:
                 "Authorization": f"Bearer {self.__api_key}",
                 "Content-Type": "application/json",
                 "Paddle-Version": str(self.use_api_version),
-                "User-Agent": "PaddleSDK/python 1.1.1",
+                "User-Agent": "PaddleSDK/python 1.1.2",
             }
         )
 

--- a/paddle_billing/Notifications/Entities/Subscription.py
+++ b/paddle_billing/Notifications/Entities/Subscription.py
@@ -69,7 +69,7 @@ class Subscription(Entity):
             paused_at=datetime.fromisoformat(data["paused_at"]) if data.get("paused_at") else None,
             started_at=datetime.fromisoformat(data["started_at"]) if data.get("started_at") else None,
             current_billing_period=(
-                TimePeriod.from_dict(data["current_billing_period"]) if data.get("billing_details") else None
+                TimePeriod.from_dict(data["current_billing_period"]) if data.get("current_billing_period") else None
             ),
             scheduled_change=(
                 SubscriptionScheduledChange.from_dict(data["scheduled_change"])

--- a/paddle_billing/Notifications/Entities/SubscriptionCreated.py
+++ b/paddle_billing/Notifications/Entities/SubscriptionCreated.py
@@ -71,7 +71,7 @@ class SubscriptionCreated(Entity):
             paused_at=datetime.fromisoformat(data["paused_at"]) if data.get("paused_at") else None,
             started_at=datetime.fromisoformat(data["started_at"]) if data.get("started_at") else None,
             current_billing_period=(
-                TimePeriod.from_dict(data["current_billing_period"]) if data.get("billing_details") else None
+                TimePeriod.from_dict(data["current_billing_period"]) if data.get("current_billing_period") else None
             ),
             scheduled_change=(
                 SubscriptionScheduledChange.from_dict(data["scheduled_change"])

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version="1.1.1",
+    version="1.1.2",
     author="Paddle and contributors",
     author_email="team-dx@paddle.com",
     description="Paddle's Python SDK for Paddle Billing",


### PR DESCRIPTION
### Fixed
- `paddle_billing.Notifications.Entities.Subscription` and `paddle_billing.Notifications.Entities.SubscriptionCreated` `current_billing_period` would return `None` if `billing_details` was `None`. `current_billing_period` will now return `TimePeriod` when set.