### PR TITLE
fix: Customer portal sessions subscription IDs / Replay Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 - Subscription IDs can be omitted when creating customer portal sessions
 - Customer portal session customer ID will always be returned as string
+- `Client.notifications.replay` now calls correct endpoint
 
 ## 1.2.0 - 2024-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.2.1 - 2024-12-04
+
+### Fixed
+
+- Subscription IDs can be omitted when creating customer portal sessions
+
 ## 1.2.0 - 2024-12-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 ### Fixed
 
 - Subscription IDs can be omitted when creating customer portal sessions
+- Customer portal session customer ID will always be returned as string
 
 ## 1.2.0 - 2024-12-03
 

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -204,7 +204,7 @@ class Client:
                 "Authorization": f"Bearer {self.__api_key}",
                 "Content-Type": "application/json",
                 "Paddle-Version": str(self.use_api_version),
-                "User-Agent": "PaddleSDK/python 1.2.0",
+                "User-Agent": "PaddleSDK/python 1.2.1",
             }
         )
 

--- a/paddle_billing/Entities/CustomerPortalSession.py
+++ b/paddle_billing/Entities/CustomerPortalSession.py
@@ -9,7 +9,7 @@ from paddle_billing.Entities.CustomerPortalSessions import CustomerPortalSession
 @dataclass
 class CustomerPortalSession(Entity):
     id: str
-    customer_id: str | None
+    customer_id: str
     urls: CustomerPortalSessionUrls
     created_at: datetime
 
@@ -17,7 +17,7 @@ class CustomerPortalSession(Entity):
     def from_dict(data: dict) -> CustomerPortalSession:
         return CustomerPortalSession(
             id=data["id"],
-            customer_id=data.get("customer_id"),
+            customer_id=data["customer_id"],
             urls=CustomerPortalSessionUrls.from_dict(data["urls"]),
             created_at=datetime.fromisoformat(data["created_at"]),
         )

--- a/paddle_billing/Resources/CustomerPortalSessions/Operations/CreateCustomerPortalSession.py
+++ b/paddle_billing/Resources/CustomerPortalSessions/Operations/CreateCustomerPortalSession.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 
 from paddle_billing.Operation import Operation
+from paddle_billing.Undefined import Undefined
 
 
 @dataclass
 class CreateCustomerPortalSession(Operation):
-    subscription_ids: list[str] = (None,)
+    subscription_ids: list[str] | Undefined = Undefined()

--- a/paddle_billing/Resources/Notifications/NotificationsClient.py
+++ b/paddle_billing/Resources/Notifications/NotificationsClient.py
@@ -34,7 +34,7 @@ class NotificationsClient:
         return Notification.from_dict(parser.get_data())
 
     def replay(self, notification_id: str) -> str:
-        self.response = self.client.post_raw(f"/notifications/{notification_id}")
+        self.response = self.client.post_raw(f"/notifications/{notification_id}/replay")
         parser = ResponseParser(self.response)
         data = parser.get_data()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version="1.2.0",
+    version="1.2.1",
     author="Paddle and contributors",
     author_email="team-dx@paddle.com",
     description="Paddle's Python SDK for Paddle Billing",

--- a/tests/Functional/Resources/CustomerPortalSessions/_fixtures/request/create_empty.json
+++ b/tests/Functional/Resources/CustomerPortalSessions/_fixtures/request/create_empty.json
@@ -1,0 +1,3 @@
+{
+    "subscription_ids": []
+}

--- a/tests/Functional/Resources/CustomerPortalSessions/_fixtures/response/full_entity_empty.json
+++ b/tests/Functional/Resources/CustomerPortalSessions/_fixtures/response/full_entity_empty.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "id": "cpls_01h4ge9r64c22exjsx0fy8b48b",
+    "customer_id": "ctm_01gysfvfy7vqhpzkq8rjmrq7an",
+    "urls": {
+      "general": {
+        "overview": "https://customer-portal.paddle.com/cpl_01j7zbyqs3vah3aafp4jf62qaw?action=overview&token=pga_eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjdG1fMDFncm5uNHp0YTVhMW1mMDJqanplN3kyeXMiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3Mjc2NzkyMzh9._oO12IejzdKmyKTwb7BLjmiILkx4_cSyGjXraOBUI_g"
+      },
+      "subscriptions": []
+    },
+    "created_at": "2024-10-25T06:53:58Z"
+  },
+  "meta": {
+    "request_id": "fa176777-4bca-49ec-aa1e-f53885333cb7"
+  }
+}

--- a/tests/Functional/Resources/CustomerPortalSessions/test_CustomerPortalSessionsClient.py
+++ b/tests/Functional/Resources/CustomerPortalSessions/test_CustomerPortalSessionsClient.py
@@ -32,10 +32,26 @@ class TestAddressesClient:
                 ReadsFixtures.read_raw_json_fixture("response/full_entity_multiple"),
                 "/customers/ctm_01gysfvfy7vqhpzkq8rjmrq7an/portal-sessions",
             ),
+            (
+                "ctm_01gysfvfy7vqhpzkq8rjmrq7an",
+                CreateCustomerPortalSession([]),
+                ReadsFixtures.read_raw_json_fixture("request/create_empty"),
+                ReadsFixtures.read_raw_json_fixture("response/full_entity_empty"),
+                "/customers/ctm_01gysfvfy7vqhpzkq8rjmrq7an/portal-sessions",
+            ),
+            (
+                "ctm_01gysfvfy7vqhpzkq8rjmrq7an",
+                CreateCustomerPortalSession(),
+                "{}",
+                ReadsFixtures.read_raw_json_fixture("response/full_entity_empty"),
+                "/customers/ctm_01gysfvfy7vqhpzkq8rjmrq7an/portal-sessions",
+            ),
         ],
         ids=[
             "Create portal session with single subscription ID",
             "Create portal session with multiple subscription IDs",
+            "Create portal session with empty subscription IDs",
+            "Create portal session with omitted subscription IDs",
         ],
     )
     def test_create_uses_expected_payload(

--- a/tests/Functional/Resources/Notifications/test_NotificationsClient.py
+++ b/tests/Functional/Resources/Notifications/test_NotificationsClient.py
@@ -259,12 +259,12 @@ class TestNotificationsClient:
                 200,
                 ReadsFixtures.read_raw_json_fixture("response/replay"),
                 "ntf_01h46h1s2zabpkdks7yt4vkgkc",
-                "/notifications/nft_01h8441jn5pcwrfhwh78jqt8hk",
+                "/notifications/nft_01h8441jn5pcwrfhwh78jqt8hk/replay",
             )
         ],
         ids=["Replay a notification by its id"],
     )
-    def test_replacy_notification_returns_expected_response(
+    def test_replay_notification_returns_expected_response(
         self,
         test_client,
         mock_requests,


### PR DESCRIPTION
### Fixed
- Subscription IDs can be omitted when creating customer portal sessions
- Customer portal session customer ID will always be returned as string
- `Client.notifications.replay` now calls correct endpoint