### PR TITLE
Improve type hints

### DIFF
--- a/examples/Utils/Requests/Request.py
+++ b/examples/Utils/Requests/Request.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from paddle_billing.Notifications.Requests import Headers
+from paddle_billing.Notifications.Requests.Headers import Headers
 
 
 class Request:

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -2,6 +2,7 @@ from json import dumps as json_dumps
 from logging import Logger, getLogger
 from requests import Response, RequestException, Session
 from requests.adapters import HTTPAdapter
+from typing import Any
 from urllib3.util.retry import Retry
 from urllib.parse import urljoin, urlencode
 from uuid import uuid4
@@ -110,7 +111,7 @@ class Client:
         self.log.debug(f"Response: {response.status_code} {response.text}")
 
     @staticmethod
-    def serialize_json_payload(payload: dict | Operation) -> str:
+    def serialize_json_payload(payload: dict[str, Any] | Operation) -> str:
         json_payload = json_dumps(payload, cls=PayloadEncoder)
         final_json = json_payload if json_payload != "[]" else "{}"
 
@@ -120,7 +121,7 @@ class Client:
         self,
         method: str,
         url: str,
-        payload: dict | Operation | None = None,
+        payload: dict[str, Any] | Operation | None = None,
     ) -> Response:
         """
         Makes an actual API call to Paddle
@@ -157,7 +158,7 @@ class Client:
             raise
 
     @staticmethod
-    def format_uri_parameters(uri: str, parameters: HasParameters | dict) -> str:
+    def format_uri_parameters(uri: str, parameters: HasParameters | dict[str, str]) -> str:
         if isinstance(parameters, HasParameters):
             parameters = parameters.get_parameters()
 
@@ -167,19 +168,22 @@ class Client:
 
         return uri
 
-    def get_raw(self, url: str, parameters: HasParameters | dict | None = None) -> Response:
+    def get_raw(self, url: str, parameters: HasParameters | dict[str, str] | None = None) -> Response:
         url = Client.format_uri_parameters(url, parameters) if parameters else url
 
         return self._make_request("GET", url, None)
 
     def post_raw(
-        self, url: str, payload: dict | Operation | None = None, parameters: HasParameters | dict | None = None
+        self,
+        url: str,
+        payload: dict[str, str] | Operation | None = None,
+        parameters: HasParameters | dict[str, str] | None = None,
     ) -> Response:
         url = Client.format_uri_parameters(url, parameters) if parameters else url
 
         return self._make_request("POST", url, payload)
 
-    def patch_raw(self, url: str, payload: dict | Operation | None) -> Response:
+    def patch_raw(self, url: str, payload: dict[str, str] | Operation | None) -> Response:
         return self._make_request("PATCH", url, payload)
 
     def delete_raw(self, url: str) -> Response:

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -47,9 +47,9 @@ class Client:
     def __init__(
         self,
         api_key: str,
-        options: Options = None,
-        http_client: Session = None,
-        logger: Logger = None,
+        options: Options | None = None,
+        http_client: Session | None = None,
+        logger: Logger | None = None,
         retry_count: int = 3,
         use_api_version: int = 1,
         timeout: float = 60.0,
@@ -167,7 +167,7 @@ class Client:
 
         return uri
 
-    def get_raw(self, url: str, parameters: HasParameters | dict = None) -> Response:
+    def get_raw(self, url: str, parameters: HasParameters | dict | None = None) -> Response:
         url = Client.format_uri_parameters(url, parameters) if parameters else url
 
         return self._make_request("GET", url, None)

--- a/paddle_billing/Entities/Address.py
+++ b/paddle_billing/Entities/Address.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import CountryCode, CustomData, ImportMeta, Status
@@ -24,7 +25,7 @@ class Address(Entity):
     import_meta: ImportMeta | None
 
     @staticmethod
-    def from_dict(data: dict) -> Address:
+    def from_dict(data: dict[str, Any]) -> Address:
         return Address(
             id=data["id"],
             customer_id=data["customer_id"],

--- a/paddle_billing/Entities/Adjustment.py
+++ b/paddle_billing/Entities/Adjustment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Adjustments import AdjustmentItem, AdjustmentTaxRatesUsed
@@ -34,7 +35,7 @@ class Adjustment(Entity):
     type: AdjustmentActionType
 
     @staticmethod
-    def from_dict(data: dict) -> Adjustment:
+    def from_dict(data: dict[str, Any]) -> Adjustment:
         return Adjustment(
             id=data["id"],
             action=Action(data["action"]),

--- a/paddle_billing/Entities/AdjustmentCreditNote.py
+++ b/paddle_billing/Entities/AdjustmentCreditNote.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 
@@ -9,5 +10,5 @@ class AdjustmentCreditNote(Entity):
     url: str
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentCreditNote:
+    def from_dict(data: dict[str, Any]) -> AdjustmentCreditNote:
         return AdjustmentCreditNote(data["url"])

--- a/paddle_billing/Entities/Adjustments/AdjustmentCustomerBalance.py
+++ b/paddle_billing/Entities/Adjustments/AdjustmentCustomerBalance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class AdjustmentCustomerBalance:
     used: str
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentCustomerBalance:
+    def from_dict(data: dict[str, Any]) -> AdjustmentCustomerBalance:
         return AdjustmentCustomerBalance(
             available=data["available"],
             reserved=data["reserved"],

--- a/paddle_billing/Entities/Adjustments/AdjustmentItem.py
+++ b/paddle_billing/Entities/Adjustments/AdjustmentItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared import AdjustmentItemTotals, AdjustmentType, Proration
 
@@ -14,7 +15,7 @@ class AdjustmentItem:
     totals: AdjustmentItemTotals
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentItem:
+    def from_dict(data: dict[str, Any]) -> AdjustmentItem:
         return AdjustmentItem(
             id=data["id"],
             item_id=data["item_id"],

--- a/paddle_billing/Entities/Adjustments/AdjustmentTaxRatesUsed.py
+++ b/paddle_billing/Entities/Adjustments/AdjustmentTaxRatesUsed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Adjustments.AdjustmentTotals import AdjustmentTotals
 
@@ -10,7 +11,7 @@ class AdjustmentTaxRatesUsed:
     totals: AdjustmentTotals
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentTaxRatesUsed:
+    def from_dict(data: dict[str, Any]) -> AdjustmentTaxRatesUsed:
         return AdjustmentTaxRatesUsed(
             tax_rate=data["tax_rate"],
             totals=AdjustmentTotals.from_dict(data["totals"]),

--- a/paddle_billing/Entities/Adjustments/AdjustmentTotals.py
+++ b/paddle_billing/Entities/Adjustments/AdjustmentTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class AdjustmentTotals:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentTotals:
+    def from_dict(data: dict[str, Any]) -> AdjustmentTotals:
         return AdjustmentTotals(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Entities/Business.py
+++ b/paddle_billing/Entities/Business.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import Contacts, CustomData, ImportMeta, Status
@@ -21,7 +22,7 @@ class Business(Entity):
     import_meta: ImportMeta | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Business:
+    def from_dict(data: dict[str, Any]) -> Business:
         return Business(
             id=data["id"],
             customer_id=data["customer_id"],

--- a/paddle_billing/Entities/Collections/AddressCollection.py
+++ b/paddle_billing/Entities/Collections/AddressCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Address import Address
 from paddle_billing.Entities.Collections.Collection import Collection
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Collections.Paginator import Paginator
 
 class AddressCollection(Collection[Address]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> AddressCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> AddressCollection:
         items: list[Address] = [Address.from_dict(item) for item in items_data]
 
         return AddressCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/AdjustmentCollection.py
+++ b/paddle_billing/Entities/Collections/AdjustmentCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Adjustment import Adjustment
 from paddle_billing.Entities.Collections.Collection import Collection
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Collections.Paginator import Paginator
 
 class AdjustmentCollection(Collection[Adjustment]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> AdjustmentCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> AdjustmentCollection:
         items: list[Adjustment] = [Adjustment.from_dict(item) for item in items_data]
 
         return AdjustmentCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/BusinessCollection.py
+++ b/paddle_billing/Entities/Collections/BusinessCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Business import Business
 from paddle_billing.Entities.Collections.Collection import Collection
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Collections.Paginator import Paginator
 
 class BusinessCollection(Collection[Business]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> BusinessCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> BusinessCollection:
 
         items: list[Business] = [Business.from_dict(item) for item in items_data]
 

--- a/paddle_billing/Entities/Collections/CreditBalanceCollection.py
+++ b/paddle_billing/Entities/Collections/CreditBalanceCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.CreditBalance import CreditBalance
 
 class CreditBalanceCollection(Collection[CreditBalance]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> CreditBalanceCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> CreditBalanceCollection:
         items: list[CreditBalance] = [CreditBalance.from_dict(item) for item in items_data]
 
         return CreditBalanceCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/CustomerCollection.py
+++ b/paddle_billing/Entities/Collections/CustomerCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Customer import Customer
 
 class CustomerCollection(Collection[Customer]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> CustomerCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> CustomerCollection:
         items: list[Customer] = [Customer.from_dict(item) for item in items_data]
 
         return CustomerCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/DiscountCollection.py
+++ b/paddle_billing/Entities/Collections/DiscountCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Discount import Discount
 
 class DiscountCollection(Collection[Discount]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> DiscountCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> DiscountCollection:
         items: list[Discount] = [Discount.from_dict(item) for item in items_data]
 
         return DiscountCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/EventCollection.py
+++ b/paddle_billing/Entities/Collections/EventCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Event import Event
 
 class EventCollection(Collection[Event]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> EventCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> EventCollection:
         items: list[Event] = [Event.from_dict(item) for item in items_data]
 
         return EventCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/EventTypeCollection.py
+++ b/paddle_billing/Entities/Collections/EventTypeCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.EventType import EventType
 
 class EventTypeCollection(Collection[EventType]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> EventTypeCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> EventTypeCollection:
         items: list[EventType] = [EventType.from_dict(item) for item in items_data]
 
         return EventTypeCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/NotificationCollection.py
+++ b/paddle_billing/Entities/Collections/NotificationCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Notification import Notification
 
 class NotificationCollection(Collection[Notification]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> NotificationCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> NotificationCollection:
         items: list[Notification] = [Notification.from_dict(item) for item in items_data]
 
         return NotificationCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/NotificationLogCollection.py
+++ b/paddle_billing/Entities/Collections/NotificationLogCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,9 @@ from paddle_billing.Entities.NotificationLog import NotificationLog
 
 class NotificationLogCollection(Collection[NotificationLog]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> NotificationLogCollection:
+    def from_list(
+        cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None
+    ) -> NotificationLogCollection:
         items: list[NotificationLog] = [NotificationLog.from_dict(item) for item in items_data]
 
         return NotificationLogCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/NotificationSettingCollection.py
+++ b/paddle_billing/Entities/Collections/NotificationSettingCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,9 @@ from paddle_billing.Entities.NotificationSetting import NotificationSetting
 
 class NotificationSettingCollection(Collection[NotificationSetting]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> NotificationSettingCollection:
+    def from_list(
+        cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None
+    ) -> NotificationSettingCollection:
         items: list[NotificationSetting] = [NotificationSetting.from_dict(item) for item in items_data]
 
         return NotificationSettingCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/Paginator.py
+++ b/paddle_billing/Entities/Collections/Paginator.py
@@ -18,7 +18,7 @@ class Paginator:
     def has_more(self) -> bool:
         return self._pagination.has_more
 
-    def next_page(self) -> "Collection":
+    def next_page(self) -> "Collection":  # type: ignore
         response = self._client.get_raw(self._pagination.next)
         response_parser = ResponseParser(response)
 

--- a/paddle_billing/Entities/Collections/PaymentMethodCollection.py
+++ b/paddle_billing/Entities/Collections/PaymentMethodCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.PaymentMethod import PaymentMethod
 
 class PaymentMethodCollection(Collection[PaymentMethod]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> PaymentMethodCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> PaymentMethodCollection:
         items: list[PaymentMethod] = [PaymentMethod.from_dict(item) for item in items_data]
 
         return PaymentMethodCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/PriceCollection.py
+++ b/paddle_billing/Entities/Collections/PriceCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Price import Price
 
 class PriceCollection(Collection[Price]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> PriceCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> PriceCollection:
         items: list[Price] = [Price.from_dict(item) for item in items_data]
 
         return PriceCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/ProductCollection.py
+++ b/paddle_billing/Entities/Collections/ProductCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Product import Product
 
 class ProductCollection(Collection[Product]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> ProductCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> ProductCollection:
         items: list[Product] = [Product.from_dict(item) for item in items_data]
 
         return ProductCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/ReportCollection.py
+++ b/paddle_billing/Entities/Collections/ReportCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Report import Report
 
 class ReportCollection(Collection[Report]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> ReportCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> ReportCollection:
         items: list[Report] = [Report.from_dict(item) for item in items_data]
 
         return ReportCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/SimulationCollection.py
+++ b/paddle_billing/Entities/Collections/SimulationCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Simulation import Simulation
 
 class SimulationCollection(Collection[Simulation]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> SimulationCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> SimulationCollection:
         items: list[Simulation] = [Simulation.from_dict(item) for item in items_data]
 
         return SimulationCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/SimulationRunCollection.py
+++ b/paddle_billing/Entities/Collections/SimulationRunCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.SimulationRun import SimulationRun
 
 class SimulationRunCollection(Collection[SimulationRun]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> SimulationRunCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> SimulationRunCollection:
         items: list[SimulationRun] = [SimulationRun.from_dict(item) for item in items_data]
 
         return SimulationRunCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/SimulationRunEventCollection.py
+++ b/paddle_billing/Entities/Collections/SimulationRunEventCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,9 @@ from paddle_billing.Entities.SimulationRunEvent import SimulationRunEvent
 
 class SimulationRunEventCollection(Collection[SimulationRunEvent]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> SimulationRunEventCollection:
+    def from_list(
+        cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None
+    ) -> SimulationRunEventCollection:
         items: list[SimulationRunEvent] = [SimulationRunEvent.from_dict(item) for item in items_data]
 
         return SimulationRunEventCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/SimulationTypeCollection.py
+++ b/paddle_billing/Entities/Collections/SimulationTypeCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,9 @@ from paddle_billing.Entities.SimulationType import SimulationType
 
 class SimulationTypeCollection(Collection[SimulationType]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> SimulationTypeCollection:
+    def from_list(
+        cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None
+    ) -> SimulationTypeCollection:
         items: list[SimulationType] = [SimulationType.from_dict(item) for item in items_data]
 
         return SimulationTypeCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/SubscriptionCollection.py
+++ b/paddle_billing/Entities/Collections/SubscriptionCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Subscription import Subscription
 
 class SubscriptionCollection(Collection[Subscription]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> SubscriptionCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> SubscriptionCollection:
         items: list[Subscription] = [Subscription.from_dict(item) for item in items_data]
 
         return SubscriptionCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/SubscriptionPreviewCollection.py
+++ b/paddle_billing/Entities/Collections/SubscriptionPreviewCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.SubscriptionPreview import SubscriptionPreview
 
 class SubscriptionPreviewCollection(Collection[SubscriptionPreview]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> SubscriptionPreviewCollection:
+    def from_list(cls, items_data: list[Any], paginator: Paginator | None = None) -> SubscriptionPreviewCollection:
         items: list[SubscriptionPreview] = [SubscriptionPreview.from_dict(item) for item in items_data]
 
         return SubscriptionPreviewCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/TransactionCollection.py
+++ b/paddle_billing/Entities/Collections/TransactionCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,7 @@ from paddle_billing.Entities.Transaction import Transaction
 
 class TransactionCollection(Collection[Transaction]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> TransactionCollection:
+    def from_list(cls, items_data: list[Any], paginator: Paginator | None = None) -> TransactionCollection:
         items: list[Transaction] = [Transaction.from_dict(item) for item in items_data]
 
         return TransactionCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/TransactionCollection.py
+++ b/paddle_billing/Entities/Collections/TransactionCollection.py
@@ -8,7 +8,7 @@ from paddle_billing.Entities.Transaction import Transaction
 
 class TransactionCollection(Collection[Transaction]):
     @classmethod
-    def from_list(cls, items_data: list[Any], paginator: Paginator | None = None) -> TransactionCollection:
+    def from_list(cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None) -> TransactionCollection:
         items: list[Transaction] = [Transaction.from_dict(item) for item in items_data]
 
         return TransactionCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/TransactionPreviewCollection.py
+++ b/paddle_billing/Entities/Collections/TransactionPreviewCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,9 @@ from paddle_billing.Entities.TransactionPreview import TransactionPreview
 
 class TransactionPreviewCollection(Collection[TransactionPreview]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> TransactionPreviewCollection:
+    def from_list(
+        cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None
+    ) -> TransactionPreviewCollection:
         items: list[TransactionPreview] = [TransactionPreview.from_dict(item) for item in items_data]
 
         return TransactionPreviewCollection(items, paginator)

--- a/paddle_billing/Entities/Collections/TransactionsDataCollection.py
+++ b/paddle_billing/Entities/Collections/TransactionsDataCollection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from paddle_billing.Entities.Collections.Collection import Collection
 from paddle_billing.Entities.Collections.Paginator import Paginator
@@ -7,7 +8,9 @@ from paddle_billing.Entities.TransactionData import TransactionData
 
 class TransactionsDataCollection(Collection[TransactionData]):
     @classmethod
-    def from_list(cls, items_data: list, paginator: Paginator | None = None) -> TransactionsDataCollection:
+    def from_list(
+        cls, items_data: list[dict[str, Any]], paginator: Paginator | None = None
+    ) -> TransactionsDataCollection:
         items: list[TransactionData] = [TransactionData.from_dict(item) for item in items_data]
 
         return TransactionsDataCollection(items, paginator)

--- a/paddle_billing/Entities/CreditBalance.py
+++ b/paddle_billing/Entities/CreditBalance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import CurrencyCode
@@ -13,7 +14,7 @@ class CreditBalance(Entity):
     balance: AdjustmentCustomerBalance
 
     @staticmethod
-    def from_dict(data: dict) -> CreditBalance:
+    def from_dict(data: dict[str, Any]) -> CreditBalance:
         return CreditBalance(
             customer_id=data["customer_id"],
             currency_code=CurrencyCode(data["currency_code"]),

--- a/paddle_billing/Entities/Customer.py
+++ b/paddle_billing/Entities/Customer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import CustomData, ImportMeta, Status
@@ -20,7 +21,7 @@ class Customer(Entity):
     import_meta: ImportMeta | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Customer:
+    def from_dict(data: dict[str, Any]) -> Customer:
         return Customer(
             id=data["id"],
             name=data.get("name"),

--- a/paddle_billing/Entities/CustomerAuthToken.py
+++ b/paddle_billing/Entities/CustomerAuthToken.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 
@@ -11,7 +12,7 @@ class CustomerAuthToken(Entity):
     expires_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> CustomerAuthToken:
+    def from_dict(data: dict[str, Any]) -> CustomerAuthToken:
         return CustomerAuthToken(
             customer_auth_token=data["customer_auth_token"],
             expires_at=datetime.fromisoformat(data["expires_at"]),

--- a/paddle_billing/Entities/CustomerPortalSession.py
+++ b/paddle_billing/Entities/CustomerPortalSession.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.CustomerPortalSessions import CustomerPortalSessionUrls
@@ -14,7 +15,7 @@ class CustomerPortalSession(Entity):
     created_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> CustomerPortalSession:
+    def from_dict(data: dict[str, Any]) -> CustomerPortalSession:
         return CustomerPortalSession(
             id=data["id"],
             customer_id=data["customer_id"],

--- a/paddle_billing/Entities/CustomerPortalSessions/CustomerPortalSessionGeneralUrl.py
+++ b/paddle_billing/Entities/CustomerPortalSessions/CustomerPortalSessionGeneralUrl.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -7,7 +8,7 @@ class CustomerPortalSessionGeneralUrl:
     overview: str
 
     @staticmethod
-    def from_dict(data: dict) -> CustomerPortalSessionGeneralUrl:
+    def from_dict(data: dict[str, Any]) -> CustomerPortalSessionGeneralUrl:
         return CustomerPortalSessionGeneralUrl(
             overview=data["overview"],
         )

--- a/paddle_billing/Entities/CustomerPortalSessions/CustomerPortalSessionSubscriptionUrl.py
+++ b/paddle_billing/Entities/CustomerPortalSessions/CustomerPortalSessionSubscriptionUrl.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class CustomerPortalSessionSubscriptionUrl:
     update_subscription_payment_method: str
 
     @staticmethod
-    def from_dict(data: dict) -> CustomerPortalSessionSubscriptionUrl:
+    def from_dict(data: dict[str, Any]) -> CustomerPortalSessionSubscriptionUrl:
         return CustomerPortalSessionSubscriptionUrl(
             id=data["id"],
             cancel_subscription=data["cancel_subscription"],

--- a/paddle_billing/Entities/CustomerPortalSessions/CustomerPortalSessionUrls.py
+++ b/paddle_billing/Entities/CustomerPortalSessions/CustomerPortalSessionUrls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.CustomerPortalSessions.CustomerPortalSessionGeneralUrl import (
     CustomerPortalSessionGeneralUrl,
@@ -15,7 +16,7 @@ class CustomerPortalSessionUrls:
     subscriptions: list[CustomerPortalSessionSubscriptionUrl]
 
     @staticmethod
-    def from_dict(data: dict) -> CustomerPortalSessionUrls:
+    def from_dict(data: dict[str, Any]) -> CustomerPortalSessionUrls:
         return CustomerPortalSessionUrls(
             general=CustomerPortalSessionGeneralUrl.from_dict(data["general"]),
             subscriptions=[

--- a/paddle_billing/Entities/Discount.py
+++ b/paddle_billing/Entities/Discount.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from .Entity import Entity
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Discounts import DiscountStatus, DiscountType
 from paddle_billing.Entities.Shared import CurrencyCode, ImportMeta, CustomData
@@ -29,7 +30,7 @@ class Discount(Entity):
     custom_data: CustomData | None
 
     @staticmethod
-    def from_dict(data: dict) -> Discount:
+    def from_dict(data: dict[str, Any]) -> Discount:
         return Discount(
             id=data["id"],
             status=DiscountStatus(data["status"]),

--- a/paddle_billing/Entities/Entity.py
+++ b/paddle_billing/Entities/Entity.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class Entity(ABC):
     @staticmethod
     @abstractmethod
-    def from_dict(data: dict):
+    def from_dict(data: dict[str, Any]):
         """
         A static factory for the entity that conforms to the Paddle API.
         """

--- a/paddle_billing/Entities/Event.py
+++ b/paddle_billing/Entities/Event.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Events import EventTypeName
@@ -18,7 +19,7 @@ class Event(Entity, ABC):
     data: NotificationEntity | UndefinedEntity
 
     @staticmethod
-    def from_dict(data: dict) -> Event:
+    def from_dict(data: dict[str, Any]) -> Event:
         return Event(
             data["event_id"],
             EventTypeName(data["event_type"]),

--- a/paddle_billing/Entities/EventType.py
+++ b/paddle_billing/Entities/EventType.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Events import EventTypeName
@@ -10,10 +11,10 @@ class EventType(Entity):
     name: EventTypeName
     description: str
     group: str
-    available_versions: list
+    available_versions: list[Any]
 
     @staticmethod
-    def from_dict(data: dict) -> EventType:
+    def from_dict(data: dict[str, Any]) -> EventType:
         return EventType(
             name=EventTypeName(data["name"]),
             description=data["description"],

--- a/paddle_billing/Entities/IPAddresses.py
+++ b/paddle_billing/Entities/IPAddresses.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 
@@ -9,7 +10,7 @@ class IPAddresses(Entity):
     ipv4_cidrs: list[str] | None
 
     @staticmethod
-    def from_dict(data: dict) -> IPAddresses:
+    def from_dict(data: dict[str, Any]) -> IPAddresses:
         return IPAddresses(
             ipv4_cidrs=data["ipv4_cidrs"],
         )

--- a/paddle_billing/Entities/Notification.py
+++ b/paddle_billing/Entities/Notification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Events import EventTypeName
@@ -24,7 +25,7 @@ class Notification(Entity):
     notification_setting_id: str
 
     @staticmethod
-    def from_dict(data: dict) -> Notification:
+    def from_dict(data: dict[str, Any]) -> Notification:
         return Notification(
             id=data["id"],
             type=EventTypeName(data["type"]),

--- a/paddle_billing/Entities/NotificationLog.py
+++ b/paddle_billing/Entities/NotificationLog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 
@@ -14,7 +15,7 @@ class NotificationLog(Entity):
     attempted_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> NotificationLog:
+    def from_dict(data: dict[str, Any]) -> NotificationLog:
         return NotificationLog(
             id=data["id"],
             response_code=data["response_code"],

--- a/paddle_billing/Entities/NotificationSetting.py
+++ b/paddle_billing/Entities/NotificationSetting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.EventType import EventType
@@ -20,7 +21,7 @@ class NotificationSetting(Entity):
     traffic_source: NotificationSettingTrafficSource
 
     @staticmethod
-    def from_dict(data: dict) -> NotificationSetting:
+    def from_dict(data: dict[str, Any]) -> NotificationSetting:
         return NotificationSetting(
             id=data["id"],
             description=data["description"],

--- a/paddle_billing/Entities/Notifications/NotificationEvent.py
+++ b/paddle_billing/Entities/Notifications/NotificationEvent.py
@@ -3,6 +3,7 @@ from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime
 import json
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Events import EventTypeName
@@ -22,7 +23,7 @@ class NotificationEvent(Entity, ABC):
     data: NotificationEntity | UndefinedEntity
 
     @staticmethod
-    def from_dict(data: dict) -> NotificationEvent:
+    def from_dict(data: dict[str, Any]) -> NotificationEvent:
         return NotificationEvent(
             data["notification_id"],
             data["event_id"],

--- a/paddle_billing/Entities/Notifications/NotificationEvent.py
+++ b/paddle_billing/Entities/Notifications/NotificationEvent.py
@@ -40,5 +40,7 @@ class NotificationEvent(Entity, ABC):
             raw_body = request.content.decode("utf-8")
         elif hasattr(request, "data"):
             raw_body = request.data.decode("utf-8")
+        else:
+            raise ValueError("Request does not have attr body, content, or data.")
 
         return NotificationEvent.from_dict(json.loads(raw_body))

--- a/paddle_billing/Entities/Notifications/NotificationPayout.py
+++ b/paddle_billing/Entities/Notifications/NotificationPayout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Notifications import NotificationPayoutStatus
@@ -14,7 +15,7 @@ class NotificationPayout(Entity):
     currency_code: CurrencyCodePayouts
 
     @staticmethod
-    def from_dict(data: dict) -> NotificationPayout:
+    def from_dict(data: dict[str, Any]) -> NotificationPayout:
         return NotificationPayout(
             id=data["id"],
             status=NotificationPayoutStatus(data["status"]),

--- a/paddle_billing/Entities/PaymentMethod.py
+++ b/paddle_billing/Entities/PaymentMethod.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import (
@@ -24,7 +25,7 @@ class PaymentMethod(Entity):
     updated_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> PaymentMethod:
+    def from_dict(data: dict[str, Any]) -> PaymentMethod:
         return PaymentMethod(
             id=data["id"],
             customer_id=data["customer_id"],

--- a/paddle_billing/Entities/Price.py
+++ b/paddle_billing/Entities/Price.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import (
@@ -37,7 +38,7 @@ class Price(Entity):
     updated_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> Price:
+    def from_dict(data: dict[str, Any]) -> Price:
         return Price(
             id=data["id"],
             product_id=data["product_id"],

--- a/paddle_billing/Entities/PricePreview.py
+++ b/paddle_billing/Entities/PricePreview.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import AddressPreview, CurrencyCode, PaymentMethodType
@@ -19,7 +20,7 @@ class PricePreview(Entity):
     available_payment_methods: list[PaymentMethodType]
 
     @staticmethod
-    def from_dict(data: dict) -> PricePreview:
+    def from_dict(data: dict[str, Any]) -> PricePreview:
         return PricePreview(
             customer_id=data.get("customer_id"),
             address_id=data.get("address_id"),

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewDetails.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewDetails.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.PricingPreviews.PricePreviewLineItem import PricePreviewLineItem
@@ -10,5 +11,5 @@ class PricePreviewDetails(Entity):
     line_items: list[PricePreviewLineItem]
 
     @staticmethod
-    def from_dict(data: dict) -> PricePreviewDetails:
+    def from_dict(data: dict[str, Any]) -> PricePreviewDetails:
         return PricePreviewDetails(line_items=[PricePreviewLineItem.from_dict(item) for item in data["line_items"]])

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewDiscounts.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewDiscounts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Discount import Discount
 
@@ -11,7 +12,7 @@ class PricePreviewDiscounts:
     formatted_total: str
 
     @staticmethod
-    def from_dict(data: dict) -> PricePreviewDiscounts:
+    def from_dict(data: dict[str, Any]) -> PricePreviewDiscounts:
         return PricePreviewDiscounts(
             discount=Discount.from_dict(data["discount"]),
             total=data["total"],

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewItem.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -8,7 +9,7 @@ class PricePreviewItem:
     quantity: int
 
     @staticmethod
-    def from_dict(data: dict) -> PricePreviewItem:
+    def from_dict(data: dict[str, Any]) -> PricePreviewItem:
         return PricePreviewItem(
             price_id=data["price_id"],
             quantity=data["quantity"],

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewLineItem.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewLineItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Price import Price
 from paddle_billing.Entities.Product import Product
@@ -23,7 +24,7 @@ class PricePreviewLineItem:
     discounts: list[PricePreviewDiscounts]
 
     @staticmethod
-    def from_dict(data: dict) -> PricePreviewLineItem:
+    def from_dict(data: dict[str, Any]) -> PricePreviewLineItem:
         return PricePreviewLineItem(
             price=Price.from_dict(data["price"]),
             quantity=data["quantity"],

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewTotalsFormatted.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewTotalsFormatted.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class PricePreviewTotalsFormatted:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> PricePreviewTotalsFormatted:
+    def from_dict(data: dict[str, Any]) -> PricePreviewTotalsFormatted:
         return PricePreviewTotalsFormatted(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Entities/PricingPreviews/PricePreviewUnitTotalsFormatted.py
+++ b/paddle_billing/Entities/PricingPreviews/PricePreviewUnitTotalsFormatted.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class PricePreviewUnitTotalsFormatted:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> PricePreviewUnitTotalsFormatted:
+    def from_dict(data: dict[str, Any]) -> PricePreviewUnitTotalsFormatted:
         return PricePreviewUnitTotalsFormatted(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Entities/Product.py
+++ b/paddle_billing/Entities/Product.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import CatalogType, CustomData, ImportMeta, Status, TaxCategory
@@ -22,7 +23,7 @@ class Product(Entity):
     type: CatalogType | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Product:
+    def from_dict(data: dict[str, Any]) -> Product:
         return Product(
             description=data.get("description"),
             id=data["id"],

--- a/paddle_billing/Entities/Report.py
+++ b/paddle_billing/Entities/Report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Reports import ReportFilter, ReportStatus, ReportType
@@ -18,7 +19,7 @@ class Report(Entity):
     updated_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> Report:
+    def from_dict(data: dict[str, Any]) -> Report:
         return Report(
             id=data["id"],
             status=ReportStatus(data["status"]),

--- a/paddle_billing/Entities/ReportCSV.py
+++ b/paddle_billing/Entities/ReportCSV.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 
@@ -9,5 +10,5 @@ class ReportCSV(Entity):
     url: str
 
     @staticmethod
-    def from_dict(data: dict) -> ReportCSV:
+    def from_dict(data: dict[str, Any]) -> ReportCSV:
         return ReportCSV(url=data["url"])

--- a/paddle_billing/Entities/Reports/ReportFilter.py
+++ b/paddle_billing/Entities/Reports/ReportFilter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Reports import ReportFilterName, ReportFilterOperator
 
@@ -8,8 +9,8 @@ from paddle_billing.Entities.Reports import ReportFilterName, ReportFilterOperat
 class ReportFilter:
     name: ReportFilterName
     operator: ReportFilterOperator | None
-    value: list | str
+    value: list[Any] | str
 
     @staticmethod
-    def from_dict(data: dict) -> ReportFilter:
+    def from_dict(data: dict[str, Any]) -> ReportFilter:
         return ReportFilter(**data)

--- a/paddle_billing/Entities/Shared/AddressPreview.py
+++ b/paddle_billing/Entities/Shared/AddressPreview.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.CountryCode import CountryCode
 
@@ -10,7 +11,7 @@ class AddressPreview:
     country_code: CountryCode
 
     @staticmethod
-    def from_dict(data: dict) -> AddressPreview:
+    def from_dict(data: dict[str, Any]) -> AddressPreview:
         return AddressPreview(
             postal_code=data.get("postal_code"),
             country_code=CountryCode(data["country_code"]),

--- a/paddle_billing/Entities/Shared/AdjustmentItemTotals.py
+++ b/paddle_billing/Entities/Shared/AdjustmentItemTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class AdjustmentItemTotals:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentItemTotals:
+    def from_dict(data: dict[str, Any]) -> AdjustmentItemTotals:
         return AdjustmentItemTotals(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Entities/Shared/AdjustmentTotals.py
+++ b/paddle_billing/Entities/Shared/AdjustmentTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -14,7 +15,7 @@ class AdjustmentTotals:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentTotals:
+    def from_dict(data: dict[str, Any]) -> AdjustmentTotals:
         return AdjustmentTotals(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Entities/Shared/BillingDetails.py
+++ b/paddle_billing/Entities/Shared/BillingDetails.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.Duration import Duration
 
@@ -12,7 +13,7 @@ class BillingDetails:
     additional_information: str | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> BillingDetails:
+    def from_dict(data: dict[str, Any]) -> BillingDetails:
         return BillingDetails(
             enable_checkout=data["enable_checkout"],
             payment_terms=Duration.from_dict(data["payment_terms"]),

--- a/paddle_billing/Entities/Shared/Card.py
+++ b/paddle_billing/Entities/Shared/Card.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Transactions.TransactionCardType import TransactionCardType
 
@@ -13,7 +14,7 @@ class Card:
     cardholder_name: str | None
 
     @staticmethod
-    def from_dict(data: dict) -> Card:
+    def from_dict(data: dict[str, Any]) -> Card:
         return Card(
             type=TransactionCardType(data["type"]),
             last4=data["last4"],

--- a/paddle_billing/Entities/Shared/ChargebackFee.py
+++ b/paddle_billing/Entities/Shared/ChargebackFee.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.Original import Original
 
@@ -10,7 +11,7 @@ class ChargebackFee:
     original: Original | None
 
     @staticmethod
-    def from_dict(data: dict) -> ChargebackFee:
+    def from_dict(data: dict[str, Any]) -> ChargebackFee:
         return ChargebackFee(
             amount=data["amount"],
             original=Original.from_dict(data["original"]) if data.get("original") else None,

--- a/paddle_billing/Entities/Shared/Checkout.py
+++ b/paddle_billing/Entities/Shared/Checkout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -7,5 +8,5 @@ class Checkout:
     url: str | None
 
     @staticmethod
-    def from_dict(data: dict) -> Checkout:
+    def from_dict(data: dict[str, Any]) -> Checkout:
         return Checkout(url=data.get("url"))

--- a/paddle_billing/Entities/Shared/Contacts.py
+++ b/paddle_billing/Entities/Shared/Contacts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -8,7 +9,7 @@ class Contacts:
     email: str
 
     @staticmethod
-    def from_dict(data: dict) -> Contacts:
+    def from_dict(data: dict[str, Any]) -> Contacts:
         return Contacts(
             name=data["name"],
             email=data["email"],

--- a/paddle_billing/Entities/Shared/CustomData.py
+++ b/paddle_billing/Entities/Shared/CustomData.py
@@ -1,7 +1,10 @@
-class CustomData:
-    data: dict | list  # JSON serializable Python types
+from typing import Any
 
-    def __init__(self, data: dict | list):
+
+class CustomData:
+    data: dict[str, Any] | list[Any]  # JSON serializable Python types
+
+    def __init__(self, data: dict[str, Any] | list[Any]):
         self.data = data
 
     def to_json(self):

--- a/paddle_billing/Entities/Shared/Data.py
+++ b/paddle_billing/Entities/Shared/Data.py
@@ -4,6 +4,6 @@ from typing import Any
 
 @dataclass
 class Data:
-    data: dict | list | Any  # TODO Any? Should be JSON serializable Python types though
+    data: dict[str, Any] | list[Any] | Any  # TODO Any? Should be JSON serializable Python types though
 
     # from_dict method isn't needed, unless specific processing of 'data' is required.

--- a/paddle_billing/Entities/Shared/Duration.py
+++ b/paddle_billing/Entities/Shared/Duration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.Interval import Interval
 
@@ -10,7 +11,7 @@ class Duration:
     frequency: int
 
     @staticmethod
-    def from_dict(data: dict) -> Duration:
+    def from_dict(data: dict[str, Any]) -> Duration:
         return Duration(
             interval=Interval(data["interval"]),
             frequency=data["frequency"],

--- a/paddle_billing/Entities/Shared/ImportMeta.py
+++ b/paddle_billing/Entities/Shared/ImportMeta.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -8,7 +9,7 @@ class ImportMeta:
     imported_from: str
 
     @staticmethod
-    def from_dict(data: dict) -> ImportMeta:
+    def from_dict(data: dict[str, Any]) -> ImportMeta:
         return ImportMeta(
             external_id=data.get("external_id"),
             imported_from=data["imported_from"],

--- a/paddle_billing/Entities/Shared/MetaPaginated.py
+++ b/paddle_billing/Entities/Shared/MetaPaginated.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.Pagination import Pagination
 
@@ -10,7 +11,7 @@ class MetaPaginated:
     pagination: Pagination
 
     @staticmethod
-    def from_dict(data: dict) -> MetaPaginated:
+    def from_dict(data: dict[str, Any]) -> MetaPaginated:
         return MetaPaginated(
             request_id=data["request_id"],
             pagination=Pagination.from_dict(data["pagination"]),

--- a/paddle_billing/Entities/Shared/MethodDetails.py
+++ b/paddle_billing/Entities/Shared/MethodDetails.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.Card import Card
 from paddle_billing.Entities.Shared.PaymentMethodType import PaymentMethodType
@@ -11,7 +12,7 @@ class MethodDetails:
     card: Card | None
 
     @staticmethod
-    def from_dict(data: dict) -> MethodDetails:
+    def from_dict(data: dict[str, Any]) -> MethodDetails:
         return MethodDetails(
             PaymentMethodType(data["type"]),
             Card.from_dict(data["card"]) if data.get("card") else None,

--- a/paddle_billing/Entities/Shared/Money.py
+++ b/paddle_billing/Entities/Shared/Money.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -20,7 +21,7 @@ class Money:
             raise ValueError("Money amount should not contain decimals or commas")
 
     @staticmethod
-    def from_dict(data: dict) -> Money:
+    def from_dict(data: dict[str, Any]) -> Money:
         return Money(
             amount=data["amount"],
             currency_code=CurrencyCode(data["currency_code"]) if data.get("currency_code") else None,

--- a/paddle_billing/Entities/Shared/Original.py
+++ b/paddle_billing/Entities/Shared/Original.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.CurrencyCodeAdjustments import CurrencyCodeAdjustments
 
@@ -10,7 +11,7 @@ class Original:
     currency_code: CurrencyCodeAdjustments
 
     @staticmethod
-    def from_dict(data: dict) -> Original:
+    def from_dict(data: dict[str, Any]) -> Original:
         return Original(
             amount=data["amount"],
             currency_code=CurrencyCodeAdjustments(data["currency_code"]),

--- a/paddle_billing/Entities/Shared/Pagination.py
+++ b/paddle_billing/Entities/Shared/Pagination.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class Pagination:
     estimated_total: int
 
     @staticmethod
-    def from_dict(data: dict) -> Pagination:
+    def from_dict(data: dict[str, Any]) -> Pagination:
         return Pagination(
             per_page=data["per_page"],
             next=data["next"],

--- a/paddle_billing/Entities/Shared/PayoutTotalsAdjustment.py
+++ b/paddle_billing/Entities/Shared/PayoutTotalsAdjustment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.ChargebackFee import ChargebackFee
 from paddle_billing.Entities.Shared.CurrencyCodePayouts import CurrencyCodePayouts
@@ -16,7 +17,7 @@ class PayoutTotalsAdjustment:
     currency_code: CurrencyCodePayouts
 
     @staticmethod
-    def from_dict(data: dict) -> PayoutTotalsAdjustment:
+    def from_dict(data: dict[str, Any]) -> PayoutTotalsAdjustment:
         return PayoutTotalsAdjustment(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Entities/Shared/Paypal.py
+++ b/paddle_billing/Entities/Shared/Paypal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -8,7 +9,7 @@ class Paypal:
     reference: str
 
     @staticmethod
-    def from_dict(data: dict) -> Paypal:
+    def from_dict(data: dict[str, Any]) -> Paypal:
         return Paypal(
             email=data["email"],
             reference=data["reference"],

--- a/paddle_billing/Entities/Shared/PriceQuantity.py
+++ b/paddle_billing/Entities/Shared/PriceQuantity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -8,7 +9,7 @@ class PriceQuantity:
     maximum: int
 
     @staticmethod
-    def from_dict(data: dict) -> PriceQuantity:
+    def from_dict(data: dict[str, Any]) -> PriceQuantity:
         return PriceQuantity(
             minimum=data["minimum"],
             maximum=data["maximum"],

--- a/paddle_billing/Entities/Shared/Proration.py
+++ b/paddle_billing/Entities/Shared/Proration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.TimePeriod import TimePeriod
 
@@ -10,7 +11,7 @@ class Proration:
     billing_period: TimePeriod
 
     @staticmethod
-    def from_dict(data: dict) -> Proration:
+    def from_dict(data: dict[str, Any]) -> Proration:
         return Proration(
             rate=data["rate"],
             billing_period=TimePeriod.from_dict(data["billing_period"]),

--- a/paddle_billing/Entities/Shared/TaxRatesUsed.py
+++ b/paddle_billing/Entities/Shared/TaxRatesUsed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.Totals import Totals
 
@@ -10,7 +11,7 @@ class TaxRatesUsed:
     totals: Totals
 
     @staticmethod
-    def from_dict(data: dict) -> TaxRatesUsed:
+    def from_dict(data: dict[str, Any]) -> TaxRatesUsed:
         return TaxRatesUsed(
             tax_rate=data["tax_rate"],
             totals=Totals.from_dict(data["totals"]),

--- a/paddle_billing/Entities/Shared/TimePeriod.py
+++ b/paddle_billing/Entities/Shared/TimePeriod.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class TimePeriod:
     ends_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> TimePeriod:
+    def from_dict(data: dict[str, Any]) -> TimePeriod:
         return TimePeriod(
             starts_at=datetime.fromisoformat(data["starts_at"]),
             ends_at=datetime.fromisoformat(data["ends_at"]),

--- a/paddle_billing/Entities/Shared/Totals.py
+++ b/paddle_billing/Entities/Shared/Totals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class Totals:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> Totals:
+    def from_dict(data: dict[str, Any]) -> Totals:
         return Totals(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Entities/Shared/TransactionDetailsPreview.py
+++ b/paddle_billing/Entities/Shared/TransactionDetailsPreview.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.TaxRatesUsed import TaxRatesUsed
 from paddle_billing.Entities.Shared.TransactionLineItemPreview import TransactionLineItemPreview
@@ -13,7 +14,7 @@ class TransactionDetailsPreview:
     line_items: list[TransactionLineItemPreview]
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionDetailsPreview:
+    def from_dict(data: dict[str, Any]) -> TransactionDetailsPreview:
         return TransactionDetailsPreview(
             totals=TransactionTotals.from_dict(data["totals"]),
             tax_rates_used=[TaxRatesUsed.from_dict(rate) for rate in data["tax_rates_used"]],

--- a/paddle_billing/Entities/Shared/TransactionLineItemPreview.py
+++ b/paddle_billing/Entities/Shared/TransactionLineItemPreview.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.TransactionPreviewProduct import TransactionPreviewProduct
 from paddle_billing.Entities.Shared.Totals import Totals
@@ -18,7 +19,7 @@ class TransactionLineItemPreview:
     proration: Proration | None
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionLineItemPreview:
+    def from_dict(data: dict[str, Any]) -> TransactionLineItemPreview:
         return TransactionLineItemPreview(
             price_id=data.get("price_id"),
             quantity=data["quantity"],

--- a/paddle_billing/Entities/Shared/TransactionPaymentAttempt.py
+++ b/paddle_billing/Entities/Shared/TransactionPaymentAttempt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Shared.ErrorCode import ErrorCode
 from paddle_billing.Entities.Shared.MethodDetails import MethodDetails
@@ -20,7 +21,7 @@ class TransactionPaymentAttempt:
     captured_at: datetime | None
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionPaymentAttempt:
+    def from_dict(data: dict[str, Any]) -> TransactionPaymentAttempt:
         return TransactionPaymentAttempt(
             payment_attempt_id=data["payment_attempt_id"],
             payment_method_id=data.get("payment_method_id"),

--- a/paddle_billing/Entities/Shared/TransactionPayoutTotals.py
+++ b/paddle_billing/Entities/Shared/TransactionPayoutTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.CurrencyCodePayouts import CurrencyCodePayouts
 
@@ -19,7 +20,7 @@ class TransactionPayoutTotals:
     credit_to_balance: str
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionPayoutTotals:
+    def from_dict(data: dict[str, Any]) -> TransactionPayoutTotals:
         return TransactionPayoutTotals(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Entities/Shared/TransactionPayoutTotalsAdjusted.py
+++ b/paddle_billing/Entities/Shared/TransactionPayoutTotalsAdjusted.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.ChargebackFee import ChargebackFee
 from paddle_billing.Entities.Shared.CurrencyCodePayouts import CurrencyCodePayouts
@@ -16,7 +17,7 @@ class TransactionPayoutTotalsAdjusted:
     currency_code: CurrencyCodePayouts
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionPayoutTotalsAdjusted:
+    def from_dict(data: dict[str, Any]) -> TransactionPayoutTotalsAdjusted:
         return TransactionPayoutTotalsAdjusted(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Entities/Shared/TransactionPreviewProduct.py
+++ b/paddle_billing/Entities/Shared/TransactionPreviewProduct.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import CatalogType, CustomData, ImportMeta, Status, TaxCategory
@@ -21,7 +22,7 @@ class TransactionPreviewProduct(Entity):
     import_meta: ImportMeta | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionPreviewProduct:
+    def from_dict(data: dict[str, Any]) -> TransactionPreviewProduct:
         return TransactionPreviewProduct(
             id=data.get("id"),
             name=data["name"],

--- a/paddle_billing/Entities/Shared/TransactionTotals.py
+++ b/paddle_billing/Entities/Shared/TransactionTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -19,7 +20,7 @@ class TransactionTotals:
     credit_to_balance: str
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionTotals:
+    def from_dict(data: dict[str, Any]) -> TransactionTotals:
         return TransactionTotals(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Entities/Shared/TransactionTotalsAdjusted.py
+++ b/paddle_billing/Entities/Shared/TransactionTotalsAdjusted.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -15,7 +16,7 @@ class TransactionTotalsAdjusted:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionTotalsAdjusted:
+    def from_dict(data: dict[str, Any]) -> TransactionTotalsAdjusted:
         return TransactionTotalsAdjusted(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Entities/Shared/UnitPriceOverride.py
+++ b/paddle_billing/Entities/Shared/UnitPriceOverride.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.CountryCode import CountryCode
 from paddle_billing.Entities.Shared.Money import Money
@@ -11,7 +12,7 @@ class UnitPriceOverride:
     unit_price: Money
 
     @staticmethod
-    def from_dict(data: dict) -> UnitPriceOverride:
+    def from_dict(data: dict[str, Any]) -> UnitPriceOverride:
         return UnitPriceOverride(
             country_codes=[CountryCode(code) for code in data["country_codes"]],
             unit_price=Money.from_dict(data["unit_price"]),

--- a/paddle_billing/Entities/Shared/UnitTotals.py
+++ b/paddle_billing/Entities/Shared/UnitTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class UnitTotals:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> UnitTotals:
+    def from_dict(data: dict[str, Any]) -> UnitTotals:
         return UnitTotals(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Entities/Simulation.py
+++ b/paddle_billing/Entities/Simulation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Events import EventTypeName
@@ -24,7 +25,7 @@ class Simulation(Entity, ABC):
     updated_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> Simulation:
+    def from_dict(data: dict[str, Any]) -> Simulation:
         type = EventTypeName(data["type"])
         if not type.is_known():
             type = SimulationScenarioType(data["type"])

--- a/paddle_billing/Entities/SimulationRun.py
+++ b/paddle_billing/Entities/SimulationRun.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Events import EventTypeName
@@ -20,7 +21,7 @@ class SimulationRun(Entity, ABC):
     events: list[SimulationRunEvent]
 
     @staticmethod
-    def from_dict(data: dict) -> SimulationRun:
+    def from_dict(data: dict[str, Any]) -> SimulationRun:
         type = EventTypeName(data["type"])
         if not type.is_known():
             type = SimulationScenarioType(data["type"])

--- a/paddle_billing/Entities/SimulationRunEvent.py
+++ b/paddle_billing/Entities/SimulationRunEvent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Events import EventTypeName
@@ -27,7 +28,7 @@ class SimulationRunEvent(Entity, ABC):
     updated_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> SimulationRunEvent:
+    def from_dict(data: dict[str, Any]) -> SimulationRunEvent:
         return SimulationRunEvent(
             id=data["id"],
             status=SimulationRunEventStatus(data["status"]),

--- a/paddle_billing/Entities/SimulationRunEvents/SimulationRunEventRequest.py
+++ b/paddle_billing/Entities/SimulationRunEvents/SimulationRunEventRequest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 
@@ -9,7 +10,7 @@ class SimulationRunEventRequest(Entity):
     body: str
 
     @staticmethod
-    def from_dict(data: dict) -> SimulationRunEventRequest:
+    def from_dict(data: dict[str, Any]) -> SimulationRunEventRequest:
         return SimulationRunEventRequest(
             body=data["body"],
         )

--- a/paddle_billing/Entities/SimulationRunEvents/SimulationRunEventResponse.py
+++ b/paddle_billing/Entities/SimulationRunEvents/SimulationRunEventResponse.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 
@@ -10,7 +11,7 @@ class SimulationRunEventResponse(Entity):
     status_code: int
 
     @staticmethod
-    def from_dict(data: dict) -> SimulationRunEventResponse:
+    def from_dict(data: dict[str, Any]) -> SimulationRunEventResponse:
         return SimulationRunEventResponse(
             body=data["body"],
             status_code=data["status_code"],

--- a/paddle_billing/Entities/SimulationType.py
+++ b/paddle_billing/Entities/SimulationType.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Events import EventTypeName
@@ -17,7 +18,7 @@ class SimulationType(Entity, ABC):
     events: list[EventTypeName]
 
     @staticmethod
-    def from_dict(data: dict) -> SimulationType:
+    def from_dict(data: dict[str, Any]) -> SimulationType:
         return SimulationType(
             name=data["name"],
             label=data["label"],

--- a/paddle_billing/Entities/Subscription.py
+++ b/paddle_billing/Entities/Subscription.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 
@@ -54,7 +55,7 @@ class Subscription(Entity):
     custom_data: CustomData | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Subscription:
+    def from_dict(data: dict[str, Any]) -> Subscription:
         return Subscription(
             id=data["id"],
             status=SubscriptionStatus(data["status"]),

--- a/paddle_billing/Entities/SubscriptionPreview.py
+++ b/paddle_billing/Entities/SubscriptionPreview.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import (
@@ -46,7 +47,7 @@ class SubscriptionPreview(Entity):
     current_billing_period: TimePeriod | None
     billing_cycle: Duration
     scheduled_change: SubscriptionScheduledChange | None
-    management_urls: SubscriptionManagementUrls
+    management_urls: SubscriptionManagementUrls | None
     items: list[SubscriptionItem]
     custom_data: CustomData | None
     immediate_transaction: SubscriptionNextTransaction | None
@@ -56,7 +57,7 @@ class SubscriptionPreview(Entity):
     import_meta: ImportMeta | None
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionPreview:
+    def from_dict(data: dict[str, Any]) -> SubscriptionPreview:
         return SubscriptionPreview(
             status=SubscriptionStatus(data["status"]),
             customer_id=data["customer_id"],

--- a/paddle_billing/Entities/Subscriptions/SubscriptionAdjustmentItem.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionAdjustmentItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared import AdjustmentItemTotals, AdjustmentType, Proration
 
@@ -13,7 +14,7 @@ class SubscriptionAdjustmentItem:
     totals: AdjustmentItemTotals
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionAdjustmentItem:
+    def from_dict(data: dict[str, Any]) -> SubscriptionAdjustmentItem:
         return SubscriptionAdjustmentItem(
             item_id=data["item_id"],
             type=AdjustmentType(data["type"]),

--- a/paddle_billing/Entities/Subscriptions/SubscriptionAdjustmentPreview.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionAdjustmentPreview.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared import AdjustmentTotals
 
@@ -13,7 +14,7 @@ class SubscriptionAdjustmentPreview:
     totals: AdjustmentTotals
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionAdjustmentPreview:
+    def from_dict(data: dict[str, Any]) -> SubscriptionAdjustmentPreview:
         return SubscriptionAdjustmentPreview(
             transaction_id=data["transaction_id"],
             items=[SubscriptionAdjustmentItem.from_dict(item) for item in data["items"]],

--- a/paddle_billing/Entities/Subscriptions/SubscriptionCharge.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionCharge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared import CurrencyCode
 
@@ -10,7 +11,7 @@ class SubscriptionCharge:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionCharge:
+    def from_dict(data: dict[str, Any]) -> SubscriptionCharge:
         return SubscriptionCharge(
             amount=data["amount"],
             currency_code=CurrencyCode(data["currency_code"]),

--- a/paddle_billing/Entities/Subscriptions/SubscriptionCredit.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionCredit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared import CurrencyCode
 
@@ -10,7 +11,7 @@ class SubscriptionCredit:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionCredit:
+    def from_dict(data: dict[str, Any]) -> SubscriptionCredit:
         return SubscriptionCredit(
             amount=data["amount"],
             currency_code=CurrencyCode(data["currency_code"]),

--- a/paddle_billing/Entities/Subscriptions/SubscriptionDiscount.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionDiscount.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class SubscriptionDiscount:
     ends_at: datetime | None
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionDiscount:
+    def from_dict(data: dict[str, Any]) -> SubscriptionDiscount:
         return SubscriptionDiscount(
             id=data["id"],
             starts_at=datetime.fromisoformat(data["starts_at"]) if data.get("starts_at") else None,

--- a/paddle_billing/Entities/Subscriptions/SubscriptionItem.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionItem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Shared.TimePeriod import TimePeriod
 
@@ -23,7 +24,7 @@ class SubscriptionItem:
     product: Product
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionItem:
+    def from_dict(data: dict[str, Any]) -> SubscriptionItem:
         return SubscriptionItem(
             status=SubscriptionItemStatus(data["status"]),
             quantity=data["quantity"],

--- a/paddle_billing/Entities/Subscriptions/SubscriptionManagementUrls.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionManagementUrls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -8,7 +9,7 @@ class SubscriptionManagementUrls:
     cancel: str
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionManagementUrls:
+    def from_dict(data: dict[str, Any]) -> SubscriptionManagementUrls:
         return SubscriptionManagementUrls(
             update_payment_method=data.get("update_payment_method"),
             cancel=data["cancel"],

--- a/paddle_billing/Entities/Subscriptions/SubscriptionNextTransaction.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionNextTransaction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.TransactionDetailsPreview import TransactionDetailsPreview
 from paddle_billing.Entities.Shared.TimePeriod import TimePeriod
@@ -14,7 +15,7 @@ class SubscriptionNextTransaction:
     adjustments: list[SubscriptionAdjustmentPreview]
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionNextTransaction:
+    def from_dict(data: dict[str, Any]) -> SubscriptionNextTransaction:
         return SubscriptionNextTransaction(
             billing_period=TimePeriod.from_dict(data["billing_period"]),
             details=TransactionDetailsPreview.from_dict(data["details"]),

--- a/paddle_billing/Entities/Subscriptions/SubscriptionPreviewSubscriptionUpdateSummary.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionPreviewSubscriptionUpdateSummary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Subscriptions.SubscriptionCharge import SubscriptionCharge
 from paddle_billing.Entities.Subscriptions.SubscriptionCredit import SubscriptionCredit
@@ -13,7 +14,7 @@ class SubscriptionPreviewSubscriptionUpdateSummary:
     result: SubscriptionResult
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionPreviewSubscriptionUpdateSummary:
+    def from_dict(data: dict[str, Any]) -> SubscriptionPreviewSubscriptionUpdateSummary:
         return SubscriptionPreviewSubscriptionUpdateSummary(
             credit=SubscriptionCredit.from_dict(data["credit"]),
             charge=SubscriptionCharge.from_dict(data["charge"]),

--- a/paddle_billing/Entities/Subscriptions/SubscriptionResult.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionResult.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared import CurrencyCode
 
@@ -13,7 +14,7 @@ class SubscriptionResult:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionResult:
+    def from_dict(data: dict[str, Any]) -> SubscriptionResult:
         return SubscriptionResult(
             action=SubscriptionResultAction(data["action"]),
             amount=data["amount"],

--- a/paddle_billing/Entities/Subscriptions/SubscriptionScheduledChange.py
+++ b/paddle_billing/Entities/Subscriptions/SubscriptionScheduledChange.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Subscriptions.SubscriptionScheduledChangeAction import SubscriptionScheduledChangeAction
 
@@ -12,7 +13,7 @@ class SubscriptionScheduledChange:
     resume_at: datetime | None
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionScheduledChange:
+    def from_dict(data: dict[str, Any]) -> SubscriptionScheduledChange:
         return SubscriptionScheduledChange(
             action=SubscriptionScheduledChangeAction(data["action"]),
             effective_at=datetime.fromisoformat(data["effective_at"]),

--- a/paddle_billing/Entities/Transaction.py
+++ b/paddle_billing/Entities/Transaction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Adjustment import Adjustment
 from paddle_billing.Entities.Entity import Entity
@@ -53,7 +54,7 @@ class Transaction(Entity):
     billed_at: datetime | None
     address: Address | None = None
     adjustments: list[Adjustment] | None = None
-    adjustment_totals: list[TransactionAdjustmentsTotals] | None = None
+    adjustment_totals: TransactionAdjustmentsTotals | None = None
     business: Business | None = None
     customer: Customer | None = None
     discount: Discount | None = None
@@ -61,7 +62,7 @@ class Transaction(Entity):
     revised_at: datetime | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Transaction:
+    def from_dict(data: dict[str, Any]) -> Transaction:
         return Transaction(
             address_id=data.get("address_id"),
             business_id=data.get("business_id"),

--- a/paddle_billing/Entities/TransactionData.py
+++ b/paddle_billing/Entities/TransactionData.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 
@@ -9,5 +10,5 @@ class TransactionData(Entity):
     url: str
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionData:
+    def from_dict(data: dict[str, Any]) -> TransactionData:
         return TransactionData(data["url"])

--- a/paddle_billing/Entities/TransactionPreview.py
+++ b/paddle_billing/Entities/TransactionPreview.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import AddressPreview, CurrencyCode, PaymentMethodType
@@ -23,7 +24,7 @@ class TransactionPreview(Entity):
     available_payment_methods: list[PaymentMethodType]
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionPreview:
+    def from_dict(data: dict[str, Any]) -> TransactionPreview:
         return TransactionPreview(
             customer_id=data.get("customer_id"),
             address_id=data.get("address_id"),

--- a/paddle_billing/Entities/Transactions/TransactionAdjustmentsTotals.py
+++ b/paddle_billing/Entities/Transactions/TransactionAdjustmentsTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -17,7 +18,7 @@ class TransactionAdjustmentsTotals:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionAdjustmentsTotals:
+    def from_dict(data: dict[str, Any]) -> TransactionAdjustmentsTotals:
         return TransactionAdjustmentsTotals(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Entities/Transactions/TransactionBreakdown.py
+++ b/paddle_billing/Entities/Transactions/TransactionBreakdown.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class TransactionBreakdown:
     chargeback: str
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionBreakdown:
+    def from_dict(data: dict[str, Any]) -> TransactionBreakdown:
         return TransactionBreakdown(
             credit=data["credit"],
             refund=data["refund"],

--- a/paddle_billing/Entities/Transactions/TransactionDetails.py
+++ b/paddle_billing/Entities/Transactions/TransactionDetails.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Shared.TaxRatesUsed import TaxRatesUsed
 from paddle_billing.Entities.Shared.TransactionPayoutTotals import TransactionPayoutTotals
@@ -20,7 +21,7 @@ class TransactionDetails:
     lineItems: list[TransactionLineItem]
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionDetails:
+    def from_dict(data: dict[str, Any]) -> TransactionDetails:
         return TransactionDetails(
             totals=TransactionTotals.from_dict(data["totals"]),
             tax_rates_used=[TaxRatesUsed.from_dict(tax_rate_used) for tax_rate_used in data["tax_rates_used"]],

--- a/paddle_billing/Entities/Transactions/TransactionItem.py
+++ b/paddle_billing/Entities/Transactions/TransactionItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Price import Price
 
@@ -13,7 +14,7 @@ class TransactionItem:
     proration: Proration | None
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionItem:
+    def from_dict(data: dict[str, Any]) -> TransactionItem:
         return TransactionItem(
             price=Price.from_dict(data["price"]),
             quantity=data["quantity"],

--- a/paddle_billing/Entities/Transactions/TransactionItemPreviewWithPrice.py
+++ b/paddle_billing/Entities/Transactions/TransactionItemPreviewWithPrice.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Transactions.TransactionPreviewPrice import TransactionPreviewPrice
 
@@ -14,7 +15,7 @@ class TransactionItemPreviewWithPrice:
     proration: Proration | None
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionItemPreviewWithPrice:
+    def from_dict(data: dict[str, Any]) -> TransactionItemPreviewWithPrice:
         return TransactionItemPreviewWithPrice(
             price=TransactionPreviewPrice.from_dict(data["price"]),
             quantity=data["quantity"],

--- a/paddle_billing/Entities/Transactions/TransactionLineItem.py
+++ b/paddle_billing/Entities/Transactions/TransactionLineItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Product import Product
 
@@ -20,7 +21,7 @@ class TransactionLineItem:
     product: Product
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionLineItem:
+    def from_dict(data: dict[str, Any]) -> TransactionLineItem:
         return TransactionLineItem(
             id=data["id"],
             price_id=data["price_id"],

--- a/paddle_billing/Entities/Transactions/TransactionPreviewPrice.py
+++ b/paddle_billing/Entities/Transactions/TransactionPreviewPrice.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Entities.Entity import Entity
 from paddle_billing.Entities.Shared import (
@@ -22,7 +23,7 @@ class TransactionPreviewPrice(Entity):
     product_id: str | None
     name: str | None
     description: str
-    type: CatalogType
+    type: CatalogType | None
     billing_cycle: Duration | None
     trial_period: Duration | None
     tax_mode: TaxMode
@@ -36,7 +37,7 @@ class TransactionPreviewPrice(Entity):
     updated_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionPreviewPrice:
+    def from_dict(data: dict[str, Any]) -> TransactionPreviewPrice:
         return TransactionPreviewPrice(
             id=data.get("id"),
             product_id=data.get("product_id"),

--- a/paddle_billing/Exceptions/SdkExceptions/InvalidArgumentException.py
+++ b/paddle_billing/Exceptions/SdkExceptions/InvalidArgumentException.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from paddle_billing.Exceptions.SdkException import SdkException
 
 
@@ -8,7 +10,7 @@ class InvalidArgumentException(SdkException):
         return InvalidArgumentException(message)
 
     @staticmethod
-    def array_contains_invalid_types(field, expected_types: list[str] | str, given: list = None):
+    def array_contains_invalid_types(field, expected_types: list[str] | str, given: list[Any] | None = None):
         if isinstance(expected_types, list):
             expected_types_str = "', '".join(expected_types)
             message = f"Expected '{field}' to only contain types '{expected_types_str}'"

--- a/paddle_billing/FiltersNone.py
+++ b/paddle_billing/FiltersNone.py
@@ -1,6 +1,9 @@
+from typing import Any
+
+
 class FiltersNone:
     @staticmethod
-    def filter_none_values(input_dict) -> dict:
+    def filter_none_values(input_dict) -> dict[str, Any]:
         """
         This method filters out values that are None from the given list
         """

--- a/paddle_billing/FiltersUndefined.py
+++ b/paddle_billing/FiltersUndefined.py
@@ -1,9 +1,10 @@
 from paddle_billing.Undefined import Undefined
+from typing import Any
 
 
 class FiltersUndefined:
     @staticmethod
-    def filter_undefined_values(input_dict) -> dict:
+    def filter_undefined_values(input_dict) -> dict[str, Any]:
         """
         This method filters out values that are None from the given list
         """

--- a/paddle_billing/HasParameters.py
+++ b/paddle_billing/HasParameters.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 class HasParameters(ABC):
     @abstractmethod
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         """
         Implementations of this method should return a dictionary of parameters
         suitable to be used in API calls, e.g., {'foo': 'bar'} which would result in foo=bar in an API call.

--- a/paddle_billing/Notifications/Entities/Address.py
+++ b/paddle_billing/Notifications/Entities/Address.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Shared import CountryCode, CustomData, ImportMeta, Status
@@ -24,7 +25,7 @@ class Address(Entity):
     customer_id: str | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Address:
+    def from_dict(data: dict[str, Any]) -> Address:
         return Address(
             id=data["id"],
             customer_id=data.get("customer_id"),

--- a/paddle_billing/Notifications/Entities/Adjustment.py
+++ b/paddle_billing/Notifications/Entities/Adjustment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Adjustments import AdjustmentItem, AdjustmentTaxRatesUsed
 from paddle_billing.Notifications.Entities.Entity import Entity
@@ -34,7 +35,7 @@ class Adjustment(Entity):
     type: AdjustmentActionType | None
 
     @staticmethod
-    def from_dict(data: dict) -> Adjustment:
+    def from_dict(data: dict[str, Any]) -> Adjustment:
         return Adjustment(
             id=data["id"],
             action=Action(data["action"]),

--- a/paddle_billing/Notifications/Entities/Adjustments/AdjustmentItem.py
+++ b/paddle_billing/Notifications/Entities/Adjustments/AdjustmentItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared import AdjustmentItemTotals, AdjustmentType, Proration
 
@@ -14,7 +15,7 @@ class AdjustmentItem:
     totals: AdjustmentItemTotals
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentItem:
+    def from_dict(data: dict[str, Any]) -> AdjustmentItem:
         return AdjustmentItem(
             id=data["id"],
             item_id=data["item_id"],

--- a/paddle_billing/Notifications/Entities/Adjustments/AdjustmentTaxRatesUsed.py
+++ b/paddle_billing/Notifications/Entities/Adjustments/AdjustmentTaxRatesUsed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Adjustments.AdjustmentTotals import AdjustmentTotals
 
@@ -10,7 +11,7 @@ class AdjustmentTaxRatesUsed:
     totals: AdjustmentTotals
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentTaxRatesUsed:
+    def from_dict(data: dict[str, Any]) -> AdjustmentTaxRatesUsed:
         return AdjustmentTaxRatesUsed(
             tax_rate=data["tax_rate"],
             totals=AdjustmentTotals.from_dict(data["totals"]),

--- a/paddle_billing/Notifications/Entities/Adjustments/AdjustmentTotals.py
+++ b/paddle_billing/Notifications/Entities/Adjustments/AdjustmentTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class AdjustmentTotals:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentTotals:
+    def from_dict(data: dict[str, Any]) -> AdjustmentTotals:
         return AdjustmentTotals(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Notifications/Entities/Business.py
+++ b/paddle_billing/Notifications/Entities/Business.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Businesses import BusinessesContacts
@@ -22,7 +23,7 @@ class Business(Entity):
     customer_id: str | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Business:
+    def from_dict(data: dict[str, Any]) -> Business:
         return Business(
             id=data["id"],
             customer_id=data.get("customer_id"),

--- a/paddle_billing/Notifications/Entities/Businesses/BusinessesContacts.py
+++ b/paddle_billing/Notifications/Entities/Businesses/BusinessesContacts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -8,7 +9,7 @@ class BusinessesContacts:
     email: str
 
     @staticmethod
-    def from_dict(data: dict) -> BusinessesContacts:
+    def from_dict(data: dict[str, Any]) -> BusinessesContacts:
         return BusinessesContacts(
             name=data["name"],
             email=data["email"],

--- a/paddle_billing/Notifications/Entities/Customer.py
+++ b/paddle_billing/Notifications/Entities/Customer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Shared import CustomData, ImportMeta, Status
@@ -20,7 +21,7 @@ class Customer(Entity):
     import_meta: ImportMeta | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Customer:
+    def from_dict(data: dict[str, Any]) -> Customer:
         return Customer(
             id=data["id"],
             name=data.get("name"),

--- a/paddle_billing/Notifications/Entities/Discount.py
+++ b/paddle_billing/Notifications/Entities/Discount.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Discounts import DiscountStatus, DiscountType
 from paddle_billing.Notifications.Entities.Entity import Entity
@@ -24,11 +25,11 @@ class Discount(Entity):
     expires_at: datetime | None = None
     import_meta: ImportMeta | None = None
     maximum_recurring_intervals: int | None = None
-    restrict_to: list | None = None
+    restrict_to: list[Any] | None = None
     usage_limit: int | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Discount:
+    def from_dict(data: dict[str, Any]) -> Discount:
         return Discount(
             amount=data["amount"],
             code=data.get("code"),

--- a/paddle_billing/Notifications/Entities/Entity.py
+++ b/paddle_billing/Notifications/Entities/Entity.py
@@ -36,7 +36,7 @@ class Entity(ABC, EntityDict):
         if not instantiated_class:
             return UndefinedEntity(data)
 
-        if type(entity_class) is not type or not issubclass(entity_class, Entity):
+        if entity_class is None or not issubclass(entity_class, Entity):
             raise ValueError(f"Event type '{entity_class_name}' is not of Entity")
 
         return instantiated_class

--- a/paddle_billing/Notifications/Entities/Entity.py
+++ b/paddle_billing/Notifications/Entities/Entity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from typing import Any
 from dataclasses import asdict, dataclass
 from importlib import import_module
 from paddle_billing.Notifications.Entities.EntityDict import EntityDict
@@ -10,14 +11,14 @@ from paddle_billing.Notifications.Entities.UndefinedEntity import UndefinedEntit
 class Entity(ABC, EntityDict):
     @staticmethod
     @abstractmethod
-    def from_dict(data: dict):
+    def from_dict(data: dict[str, Any]):
         """
         A static factory for the entity that conforms to the Paddle API.
         """
         pass
 
     @staticmethod
-    def from_dict_for_event_type(data: dict, event_type: str) -> Entity | UndefinedEntity:
+    def from_dict_for_event_type(data: dict[str, Any], event_type: str) -> Entity | UndefinedEntity:
         entity_class_name = Entity._resolve_event_class_name(event_type)
 
         entity_class = None
@@ -35,7 +36,7 @@ class Entity(ABC, EntityDict):
         if not instantiated_class:
             return UndefinedEntity(data)
 
-        if not issubclass(entity_class, Entity):
+        if type(entity_class) is not type or not issubclass(entity_class, Entity):
             raise ValueError(f"Event type '{entity_class_name}' is not of Entity")
 
         return instantiated_class
@@ -51,5 +52,5 @@ class Entity(ABC, EntityDict):
 
         return event_entity.lower().title().replace("_", "")
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/paddle_billing/Notifications/Entities/EntityDict.py
+++ b/paddle_billing/Notifications/Entities/EntityDict.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from typing import Protocol
+from typing import Protocol, Any
 
 
 class EntityDict(Protocol):
-    def to_dict(self) -> dict: ...
+    def to_dict(self) -> dict[str, Any]: ...

--- a/paddle_billing/Notifications/Entities/PaymentMethod.py
+++ b/paddle_billing/Notifications/Entities/PaymentMethod.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Shared import (
@@ -20,7 +21,7 @@ class PaymentMethod(Entity):
     updated_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> PaymentMethod:
+    def from_dict(data: dict[str, Any]) -> PaymentMethod:
         return PaymentMethod(
             id=data["id"],
             customer_id=data["customer_id"],

--- a/paddle_billing/Notifications/Entities/PaymentMethodDeleted.py
+++ b/paddle_billing/Notifications/Entities/PaymentMethodDeleted.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Shared import (
@@ -22,7 +23,7 @@ class PaymentMethodDeleted(Entity):
     deletion_reason: SavedPaymentMethodDeletionReason
 
     @staticmethod
-    def from_dict(data: dict) -> PaymentMethodDeleted:
+    def from_dict(data: dict[str, Any]) -> PaymentMethodDeleted:
         return PaymentMethodDeleted(
             id=data["id"],
             customer_id=data["customer_id"],

--- a/paddle_billing/Notifications/Entities/Payout.py
+++ b/paddle_billing/Notifications/Entities/Payout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Payouts import PayoutStatus
@@ -14,7 +15,7 @@ class Payout(Entity):
     status: PayoutStatus
 
     @staticmethod
-    def from_dict(data: dict) -> Payout:
+    def from_dict(data: dict[str, Any]) -> Payout:
         return Payout(
             amount=data["amount"],
             id=data["id"],

--- a/paddle_billing/Notifications/Entities/Price.py
+++ b/paddle_billing/Notifications/Entities/Price.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Shared import (
@@ -36,7 +37,7 @@ class Price(Entity):
     updated_at: datetime | None
 
     @classmethod
-    def from_dict(cls, data: dict) -> Price:
+    def from_dict(cls, data: dict[str, Any]) -> Price:
         return Price(
             id=data["id"],
             product_id=data["product_id"],

--- a/paddle_billing/Notifications/Entities/Product.py
+++ b/paddle_billing/Notifications/Entities/Product.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Shared import CatalogType, CustomData, ImportMeta, Status, TaxCategory
@@ -24,7 +25,7 @@ class Product(Entity):
     updated_at: datetime | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Product:
+    def from_dict(data: dict[str, Any]) -> Product:
         return Product(
             description=data.get("description"),
             id=data["id"],

--- a/paddle_billing/Notifications/Entities/Report.py
+++ b/paddle_billing/Notifications/Entities/Report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Reports import ReportFilter, ReportStatus, ReportType
@@ -18,7 +19,7 @@ class Report(Entity):
     updated_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> Report:
+    def from_dict(data: dict[str, Any]) -> Report:
         return Report(
             id=data["id"],
             status=ReportStatus(data["status"]),

--- a/paddle_billing/Notifications/Entities/Reports/ReportFilter.py
+++ b/paddle_billing/Notifications/Entities/Reports/ReportFilter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Reports import ReportFilterName, ReportFilterOperator
 
@@ -8,8 +9,8 @@ from paddle_billing.Notifications.Entities.Reports import ReportFilterName, Repo
 class ReportFilter:
     name: ReportFilterName
     operator: ReportFilterOperator | None
-    value: list | str
+    value: list[Any] | str
 
     @staticmethod
-    def from_dict(data: dict) -> ReportFilter:
+    def from_dict(data: dict[str, Any]) -> ReportFilter:
         return ReportFilter(**data)

--- a/paddle_billing/Notifications/Entities/Shared/AddressPreview.py
+++ b/paddle_billing/Notifications/Entities/Shared/AddressPreview.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.CountryCode import CountryCode
 
@@ -10,7 +11,7 @@ class AddressPreview:
     country_code: CountryCode
 
     @staticmethod
-    def from_dict(data: dict) -> AddressPreview:
+    def from_dict(data: dict[str, Any]) -> AddressPreview:
         return AddressPreview(
             postal_code=data.get("postal_code"),
             country_code=CountryCode(data["country_code"]),

--- a/paddle_billing/Notifications/Entities/Shared/AdjustmentItemTotals.py
+++ b/paddle_billing/Notifications/Entities/Shared/AdjustmentItemTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class AdjustmentItemTotals:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentItemTotals:
+    def from_dict(data: dict[str, Any]) -> AdjustmentItemTotals:
         return AdjustmentItemTotals(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Notifications/Entities/Shared/AdjustmentTotals.py
+++ b/paddle_billing/Notifications/Entities/Shared/AdjustmentTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -14,7 +15,7 @@ class AdjustmentTotals:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> AdjustmentTotals:
+    def from_dict(data: dict[str, Any]) -> AdjustmentTotals:
         return AdjustmentTotals(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Notifications/Entities/Shared/BillingDetails.py
+++ b/paddle_billing/Notifications/Entities/Shared/BillingDetails.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.Duration import Duration
 
@@ -12,7 +13,7 @@ class BillingDetails:
     additional_information: str | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> BillingDetails:
+    def from_dict(data: dict[str, Any]) -> BillingDetails:
         return BillingDetails(
             enable_checkout=data["enable_checkout"],
             payment_terms=Duration.from_dict(data["payment_terms"]),

--- a/paddle_billing/Notifications/Entities/Shared/Card.py
+++ b/paddle_billing/Notifications/Entities/Shared/Card.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Entities.Transactions.TransactionCardType import TransactionCardType
 
@@ -13,7 +14,7 @@ class Card:
     cardholder_name: str | None
 
     @staticmethod
-    def from_dict(data: dict) -> Card:
+    def from_dict(data: dict[str, Any]) -> Card:
         return Card(
             type=TransactionCardType(data["type"]),
             last4=data["last4"],

--- a/paddle_billing/Notifications/Entities/Shared/ChargebackFee.py
+++ b/paddle_billing/Notifications/Entities/Shared/ChargebackFee.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.Original import Original
 
@@ -10,7 +11,7 @@ class ChargebackFee:
     original: Original | None
 
     @staticmethod
-    def from_dict(data: dict) -> ChargebackFee:
+    def from_dict(data: dict[str, Any]) -> ChargebackFee:
         return ChargebackFee(
             amount=data["amount"],
             original=Original.from_dict(data["original"]) if data.get("original") else None,

--- a/paddle_billing/Notifications/Entities/Shared/Checkout.py
+++ b/paddle_billing/Notifications/Entities/Shared/Checkout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -7,5 +8,5 @@ class Checkout:
     url: str | None
 
     @staticmethod
-    def from_dict(data: dict) -> Checkout:
+    def from_dict(data: dict[str, Any]) -> Checkout:
         return Checkout(url=data.get("url"))

--- a/paddle_billing/Notifications/Entities/Shared/CustomData.py
+++ b/paddle_billing/Notifications/Entities/Shared/CustomData.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
 class CustomData:
-    data: dict | list  # JSON serializable Python types
+    data: dict[str, Any] | list[Any]  # JSON serializable Python types
 
     def to_json(self):
         return self.data

--- a/paddle_billing/Notifications/Entities/Shared/Data.py
+++ b/paddle_billing/Notifications/Entities/Shared/Data.py
@@ -4,6 +4,6 @@ from typing import Any
 
 @dataclass
 class Data:
-    data: dict | list | Any  # TODO Any? Should be JSON serializable Python types though
+    data: dict[str, Any] | list[Any] | Any  # TODO Any? Should be JSON serializable Python types though
 
     # from_dict method isn't needed, unless specific processing of 'data' is required.

--- a/paddle_billing/Notifications/Entities/Shared/Duration.py
+++ b/paddle_billing/Notifications/Entities/Shared/Duration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.Interval import Interval
 
@@ -10,7 +11,7 @@ class Duration:
     frequency: int
 
     @staticmethod
-    def from_dict(data: dict) -> Duration:
+    def from_dict(data: dict[str, Any]) -> Duration:
         return Duration(
             interval=Interval(data["interval"]),
             frequency=data["frequency"],

--- a/paddle_billing/Notifications/Entities/Shared/ImportMeta.py
+++ b/paddle_billing/Notifications/Entities/Shared/ImportMeta.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -8,7 +9,7 @@ class ImportMeta:
     imported_from: str
 
     @staticmethod
-    def from_dict(data: dict) -> ImportMeta:
+    def from_dict(data: dict[str, Any]) -> ImportMeta:
         return ImportMeta(
             external_id=data.get("external_id"),
             imported_from=data["imported_from"],

--- a/paddle_billing/Notifications/Entities/Shared/MethodDetails.py
+++ b/paddle_billing/Notifications/Entities/Shared/MethodDetails.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.Card import Card
 from paddle_billing.Notifications.Entities.Shared.PaymentMethodType import PaymentMethodType
@@ -11,7 +12,7 @@ class MethodDetails:
     card: Card | None
 
     @staticmethod
-    def from_dict(data: dict) -> MethodDetails:
+    def from_dict(data: dict[str, Any]) -> MethodDetails:
         return MethodDetails(
             PaymentMethodType(data["type"]),
             Card.from_dict(data["card"]) if data.get("card") else None,

--- a/paddle_billing/Notifications/Entities/Shared/Money.py
+++ b/paddle_billing/Notifications/Entities/Shared/Money.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -20,7 +21,7 @@ class Money:
             raise ValueError("Money amount should not contain decimals or commas")
 
     @staticmethod
-    def from_dict(data: dict) -> Money:
+    def from_dict(data: dict[str, Any]) -> Money:
         return Money(
             amount=data["amount"],
             currency_code=CurrencyCode(data["currency_code"]) if data.get("currency_code") else None,

--- a/paddle_billing/Notifications/Entities/Shared/Original.py
+++ b/paddle_billing/Notifications/Entities/Shared/Original.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.CurrencyCodeAdjustments import CurrencyCodeAdjustments
 
@@ -10,7 +11,7 @@ class Original:
     currency_code: CurrencyCodeAdjustments
 
     @staticmethod
-    def from_dict(data: dict) -> Original:
+    def from_dict(data: dict[str, Any]) -> Original:
         return Original(
             amount=data["amount"],
             currency_code=CurrencyCodeAdjustments(data["currency_code"]),

--- a/paddle_billing/Notifications/Entities/Shared/PayoutTotalsAdjustment.py
+++ b/paddle_billing/Notifications/Entities/Shared/PayoutTotalsAdjustment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.ChargebackFee import ChargebackFee
 from paddle_billing.Notifications.Entities.Shared.CurrencyCodePayouts import CurrencyCodePayouts
@@ -16,7 +17,7 @@ class PayoutTotalsAdjustment:
     currency_code: CurrencyCodePayouts
 
     @staticmethod
-    def from_dict(data: dict) -> PayoutTotalsAdjustment:
+    def from_dict(data: dict[str, Any]) -> PayoutTotalsAdjustment:
         return PayoutTotalsAdjustment(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Notifications/Entities/Shared/Paypal.py
+++ b/paddle_billing/Notifications/Entities/Shared/Paypal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -8,7 +9,7 @@ class Paypal:
     reference: str
 
     @staticmethod
-    def from_dict(data: dict) -> Paypal:
+    def from_dict(data: dict[str, Any]) -> Paypal:
         return Paypal(
             email=data["email"],
             reference=data["reference"],

--- a/paddle_billing/Notifications/Entities/Shared/PriceQuantity.py
+++ b/paddle_billing/Notifications/Entities/Shared/PriceQuantity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -8,7 +9,7 @@ class PriceQuantity:
     maximum: int
 
     @staticmethod
-    def from_dict(data: dict) -> PriceQuantity:
+    def from_dict(data: dict[str, Any]) -> PriceQuantity:
         return PriceQuantity(
             minimum=data["minimum"],
             maximum=data["maximum"],

--- a/paddle_billing/Notifications/Entities/Shared/Proration.py
+++ b/paddle_billing/Notifications/Entities/Shared/Proration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.TimePeriod import TimePeriod
 
@@ -10,7 +11,7 @@ class Proration:
     billing_period: TimePeriod
 
     @staticmethod
-    def from_dict(data: dict) -> Proration:
+    def from_dict(data: dict[str, Any]) -> Proration:
         return Proration(
             rate=data["rate"],
             billing_period=TimePeriod.from_dict(data["billing_period"]),

--- a/paddle_billing/Notifications/Entities/Shared/TaxRatesUsed.py
+++ b/paddle_billing/Notifications/Entities/Shared/TaxRatesUsed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.Totals import Totals
 
@@ -10,7 +11,7 @@ class TaxRatesUsed:
     totals: Totals
 
     @staticmethod
-    def from_dict(data: dict) -> TaxRatesUsed:
+    def from_dict(data: dict[str, Any]) -> TaxRatesUsed:
         return TaxRatesUsed(
             tax_rate=data["tax_rate"],
             totals=Totals.from_dict(data["totals"]),

--- a/paddle_billing/Notifications/Entities/Shared/TimePeriod.py
+++ b/paddle_billing/Notifications/Entities/Shared/TimePeriod.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class TimePeriod:
     ends_at: datetime
 
     @staticmethod
-    def from_dict(data: dict) -> TimePeriod:
+    def from_dict(data: dict[str, Any]) -> TimePeriod:
         return TimePeriod(
             starts_at=datetime.fromisoformat(data["starts_at"]),
             ends_at=datetime.fromisoformat(data["ends_at"]),

--- a/paddle_billing/Notifications/Entities/Shared/Totals.py
+++ b/paddle_billing/Notifications/Entities/Shared/Totals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class Totals:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> Totals:
+    def from_dict(data: dict[str, Any]) -> Totals:
         return Totals(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Notifications/Entities/Shared/TransactionPaymentAttempt.py
+++ b/paddle_billing/Notifications/Entities/Shared/TransactionPaymentAttempt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.ErrorCode import ErrorCode
 from paddle_billing.Notifications.Entities.Shared.MethodDetails import MethodDetails
@@ -20,7 +21,7 @@ class TransactionPaymentAttempt:
     captured_at: datetime | None
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionPaymentAttempt:
+    def from_dict(data: dict[str, Any]) -> TransactionPaymentAttempt:
         return TransactionPaymentAttempt(
             payment_attempt_id=data["payment_attempt_id"],
             payment_method_id=data["payment_method_id"],

--- a/paddle_billing/Notifications/Entities/Shared/TransactionPayoutTotals.py
+++ b/paddle_billing/Notifications/Entities/Shared/TransactionPayoutTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.CurrencyCodePayouts import CurrencyCodePayouts
 
@@ -19,7 +20,7 @@ class TransactionPayoutTotals:
     credit_to_balance: str
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionPayoutTotals:
+    def from_dict(data: dict[str, Any]) -> TransactionPayoutTotals:
         return TransactionPayoutTotals(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Notifications/Entities/Shared/TransactionPayoutTotalsAdjusted.py
+++ b/paddle_billing/Notifications/Entities/Shared/TransactionPayoutTotalsAdjusted.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.ChargebackFee import ChargebackFee
 from paddle_billing.Notifications.Entities.Shared.CurrencyCodePayouts import CurrencyCodePayouts
@@ -16,7 +17,7 @@ class TransactionPayoutTotalsAdjusted:
     currency_code: CurrencyCodePayouts
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionPayoutTotalsAdjusted:
+    def from_dict(data: dict[str, Any]) -> TransactionPayoutTotalsAdjusted:
         return TransactionPayoutTotalsAdjusted(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Notifications/Entities/Shared/TransactionTotals.py
+++ b/paddle_billing/Notifications/Entities/Shared/TransactionTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -19,7 +20,7 @@ class TransactionTotals:
     credit_to_balance: str
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionTotals:
+    def from_dict(data: dict[str, Any]) -> TransactionTotals:
         return TransactionTotals(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Notifications/Entities/Shared/TransactionTotalsAdjusted.py
+++ b/paddle_billing/Notifications/Entities/Shared/TransactionTotalsAdjusted.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -15,7 +16,7 @@ class TransactionTotalsAdjusted:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionTotalsAdjusted:
+    def from_dict(data: dict[str, Any]) -> TransactionTotalsAdjusted:
         return TransactionTotalsAdjusted(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Notifications/Entities/Shared/UnitPriceOverride.py
+++ b/paddle_billing/Notifications/Entities/Shared/UnitPriceOverride.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.CountryCode import CountryCode
 from paddle_billing.Notifications.Entities.Shared.Money import Money
@@ -11,7 +12,7 @@ class UnitPriceOverride:
     unit_price: Money
 
     @staticmethod
-    def from_dict(data: dict) -> UnitPriceOverride:
+    def from_dict(data: dict[str, Any]) -> UnitPriceOverride:
         return UnitPriceOverride(
             country_codes=[CountryCode(code) for code in data["country_codes"]],
             unit_price=Money.from_dict(data["unit_price"]),

--- a/paddle_billing/Notifications/Entities/Shared/UnitTotals.py
+++ b/paddle_billing/Notifications/Entities/Shared/UnitTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class UnitTotals:
     total: str
 
     @staticmethod
-    def from_dict(data: dict) -> UnitTotals:
+    def from_dict(data: dict[str, Any]) -> UnitTotals:
         return UnitTotals(
             subtotal=data["subtotal"],
             discount=data["discount"],

--- a/paddle_billing/Notifications/Entities/Simulations/Address.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Address.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Shared import CountryCode, CustomData, ImportMeta, Status
@@ -25,7 +26,7 @@ class Address(SimulationEntity):
     customer_id: str | None | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Address:
+    def from_dict(data: dict[str, Any]) -> Address:
         return Address(
             id=data.get("id", Undefined()),
             customer_id=data.get("customer_id", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/Adjustment.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Adjustment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Adjustments import AdjustmentItem, AdjustmentTaxRatesUsed
@@ -35,7 +36,7 @@ class Adjustment(SimulationEntity):
     type: AdjustmentActionType | None | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Adjustment:
+    def from_dict(data: dict[str, Any]) -> Adjustment:
         return Adjustment(
             id=data.get("id", Undefined()),
             action=Action(data["action"]) if data.get("action") else Undefined(),

--- a/paddle_billing/Notifications/Entities/Simulations/Business.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Business.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Businesses import BusinessesContacts
@@ -23,7 +24,7 @@ class Business(SimulationEntity):
     customer_id: str | None | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Business:
+    def from_dict(data: dict[str, Any]) -> Business:
         return Business(
             id=data.get("id", Undefined()),
             customer_id=data.get("customer_id", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/Customer.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Customer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Shared import CustomData, ImportMeta, Status
@@ -21,7 +22,7 @@ class Customer(SimulationEntity):
     import_meta: ImportMeta | None | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Customer:
+    def from_dict(data: dict[str, Any]) -> Customer:
         return Customer(
             id=data.get("id", Undefined()),
             name=data.get("name", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/Discount.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Discount.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Discounts import DiscountStatus, DiscountType
@@ -25,11 +26,11 @@ class Discount(SimulationEntity):
     expires_at: datetime | None | Undefined = Undefined()
     import_meta: ImportMeta | None | Undefined = Undefined()
     maximum_recurring_intervals: int | None | Undefined = Undefined()
-    restrict_to: list | None | Undefined = Undefined()
+    restrict_to: list[Any] | None | Undefined = Undefined()
     usage_limit: int | None | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Discount:
+    def from_dict(data: dict[str, Any]) -> Discount:
         return Discount(
             amount=data.get("amount", Undefined()),
             code=data.get("code", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/PaymentMethod.py
+++ b/paddle_billing/Notifications/Entities/Simulations/PaymentMethod.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Shared import (
@@ -21,7 +22,7 @@ class PaymentMethod(SimulationEntity):
     updated_at: datetime | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> PaymentMethod:
+    def from_dict(data: dict[str, Any]) -> PaymentMethod:
         return PaymentMethod(
             id=data.get("id", Undefined()),
             customer_id=data.get("customer_id", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/PaymentMethodDeleted.py
+++ b/paddle_billing/Notifications/Entities/Simulations/PaymentMethodDeleted.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Shared import (
@@ -23,7 +24,7 @@ class PaymentMethodDeleted(SimulationEntity):
     deletion_reason: SavedPaymentMethodDeletionReason | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> PaymentMethodDeleted:
+    def from_dict(data: dict[str, Any]) -> PaymentMethodDeleted:
         return PaymentMethodDeleted(
             id=data.get("id", Undefined()),
             customer_id=data.get("customer_id", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/Payout.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Payout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Payouts import PayoutStatus
@@ -15,7 +16,7 @@ class Payout(SimulationEntity):
     status: PayoutStatus | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Payout:
+    def from_dict(data: dict[str, Any]) -> Payout:
         return Payout(
             amount=data.get("amount", Undefined()),
             id=data.get("id", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/Price.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Price.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Shared import (
@@ -37,7 +38,7 @@ class Price(SimulationEntity):
     updated_at: datetime | None | Undefined = Undefined()
 
     @classmethod
-    def from_dict(cls, data: dict) -> Price:
+    def from_dict(cls, data: dict[str, Any]) -> Price:
         return Price(
             id=data.get("id", Undefined()),
             product_id=data.get("product_id", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/Product.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Product.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Shared import CatalogType, CustomData, ImportMeta, Status, TaxCategory
@@ -22,7 +23,7 @@ class Product(SimulationEntity):
     updated_at: datetime | None | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Product:
+    def from_dict(data: dict[str, Any]) -> Product:
         return Product(
             description=data.get("description", Undefined()),
             id=data.get("id", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/Report.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Reports import ReportFilter, ReportStatus, ReportType
@@ -19,7 +20,7 @@ class Report(SimulationEntity):
     updated_at: datetime | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Report:
+    def from_dict(data: dict[str, Any]) -> Report:
         return Report(
             id=data.get("id", Undefined()),
             status=ReportStatus(data["status"]) if data.get("status") else Undefined(),

--- a/paddle_billing/Notifications/Entities/Simulations/SimulationEntity.py
+++ b/paddle_billing/Notifications/Entities/Simulations/SimulationEntity.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 from dataclasses import dataclass
 from abc import ABC
 from paddle_billing.Notifications.Entities.UndefinedEntity import UndefinedEntity
@@ -8,7 +9,7 @@ from importlib import import_module
 @dataclass
 class SimulationEntity(ABC):
     @staticmethod
-    def from_dict_for_event_type(data: dict, event_type: str) -> SimulationEntity | UndefinedEntity:
+    def from_dict_for_event_type(data: dict[str, Any], event_type: str) -> SimulationEntity | UndefinedEntity:
         entity_class_name = SimulationEntity._resolve_event_class_name(event_type)
 
         entity_class = None
@@ -26,7 +27,7 @@ class SimulationEntity(ABC):
         if not instantiated_class:
             return UndefinedEntity(data)
 
-        if not issubclass(entity_class, SimulationEntity):
+        if type(entity_class) is not type or not issubclass(entity_class, SimulationEntity):
             raise ValueError(f"Event type '{entity_class_name}' is not of SimulationEntity")
 
         return instantiated_class

--- a/paddle_billing/Notifications/Entities/Simulations/SimulationEntity.py
+++ b/paddle_billing/Notifications/Entities/Simulations/SimulationEntity.py
@@ -27,7 +27,7 @@ class SimulationEntity(ABC):
         if not instantiated_class:
             return UndefinedEntity(data)
 
-        if type(entity_class) is not type or not issubclass(entity_class, SimulationEntity):
+        if entity_class is None or not issubclass(entity_class, SimulationEntity):
             raise ValueError(f"Event type '{entity_class_name}' is not of SimulationEntity")
 
         return instantiated_class

--- a/paddle_billing/Notifications/Entities/Simulations/Subscription.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Subscription.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Shared import (
@@ -47,7 +48,7 @@ class Subscription(SimulationEntity):
     started_at: datetime | None | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Subscription:
+    def from_dict(data: dict[str, Any]) -> Subscription:
         return Subscription(
             id=data.get("id", Undefined()),
             status=SubscriptionStatus(data["status"]) if data.get("status") else Undefined(),

--- a/paddle_billing/Notifications/Entities/Simulations/SubscriptionCreated.py
+++ b/paddle_billing/Notifications/Entities/Simulations/SubscriptionCreated.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Shared import (
@@ -48,7 +49,7 @@ class SubscriptionCreated(SimulationEntity):
     transaction_id: str | None | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionCreated:
+    def from_dict(data: dict[str, Any]) -> SubscriptionCreated:
         return SubscriptionCreated(
             id=data.get("id", Undefined()),
             transaction_id=data.get("transaction_id", Undefined()),

--- a/paddle_billing/Notifications/Entities/Simulations/Transaction.py
+++ b/paddle_billing/Notifications/Entities/Simulations/Transaction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Undefined import Undefined
 from paddle_billing.Notifications.Entities.Shared import (
@@ -47,7 +48,7 @@ class Transaction(SimulationEntity):
     revised_at: datetime | None | Undefined = Undefined()
 
     @staticmethod
-    def from_dict(data: dict) -> Transaction:
+    def from_dict(data: dict[str, Any]) -> Transaction:
         return Transaction(
             address_id=data.get("address_id", Undefined()),
             business_id=data.get("business_id", Undefined()),

--- a/paddle_billing/Notifications/Entities/Subscription.py
+++ b/paddle_billing/Notifications/Entities/Subscription.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Shared import (
@@ -46,7 +47,7 @@ class Subscription(Entity):
     started_at: datetime | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Subscription:
+    def from_dict(data: dict[str, Any]) -> Subscription:
         return Subscription(
             id=data["id"],
             status=SubscriptionStatus(data["status"]),

--- a/paddle_billing/Notifications/Entities/SubscriptionCreated.py
+++ b/paddle_billing/Notifications/Entities/SubscriptionCreated.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Shared import (
@@ -47,7 +48,7 @@ class SubscriptionCreated(Entity):
     transaction_id: str | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionCreated:
+    def from_dict(data: dict[str, Any]) -> SubscriptionCreated:
         return SubscriptionCreated(
             id=data["id"],
             transaction_id=data.get("transaction_id"),

--- a/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionAdjustmentItem.py
+++ b/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionAdjustmentItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared import AdjustmentItemTotals, AdjustmentType, Proration
 
@@ -13,7 +14,7 @@ class SubscriptionAdjustmentItem:
     totals: AdjustmentItemTotals
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionAdjustmentItem:
+    def from_dict(data: dict[str, Any]) -> SubscriptionAdjustmentItem:
         return SubscriptionAdjustmentItem(
             item_id=data["item_id"],
             type=AdjustmentType(data["type"]),

--- a/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionCharge.py
+++ b/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionCharge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared import CurrencyCode
 
@@ -10,7 +11,7 @@ class SubscriptionCharge:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionCharge:
+    def from_dict(data: dict[str, Any]) -> SubscriptionCharge:
         return SubscriptionCharge(
             amount=data["amount"],
             currency_code=CurrencyCode(data["currency_code"]),

--- a/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionCredit.py
+++ b/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionCredit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared import CurrencyCode
 
@@ -10,7 +11,7 @@ class SubscriptionCredit:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionCredit:
+    def from_dict(data: dict[str, Any]) -> SubscriptionCredit:
         return SubscriptionCredit(
             amount=data["amount"],
             currency_code=CurrencyCode(data["currency_code"]),

--- a/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionDiscount.py
+++ b/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionDiscount.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class SubscriptionDiscount:
     ends_at: datetime | None
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionDiscount:
+    def from_dict(data: dict[str, Any]) -> SubscriptionDiscount:
         return SubscriptionDiscount(
             id=data["id"],
             starts_at=datetime.fromisoformat(data["starts_at"]) if data.get("starts_at") else None,

--- a/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionItem.py
+++ b/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionItem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.TimePeriod import TimePeriod
 
@@ -23,7 +24,7 @@ class SubscriptionItem:
     product: Product | None
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionItem:
+    def from_dict(data: dict[str, Any]) -> SubscriptionItem:
         return SubscriptionItem(
             status=SubscriptionItemStatus(data["status"]),
             quantity=data["quantity"],

--- a/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionPrice.py
+++ b/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionPrice.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared import (
     CatalogType,
@@ -35,7 +36,7 @@ class SubscriptionPrice:
     updated_at: datetime | None
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionPrice:
+    def from_dict(data: dict[str, Any]) -> SubscriptionPrice:
         return SubscriptionPrice(
             id=data["id"],
             product_id=data["product_id"],

--- a/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionScheduledChange.py
+++ b/paddle_billing/Notifications/Entities/Subscriptions/SubscriptionScheduledChange.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Subscriptions.SubscriptionScheduledChangeAction import (
     SubscriptionScheduledChangeAction,
@@ -14,7 +15,7 @@ class SubscriptionScheduledChange:
     resume_at: datetime | None
 
     @staticmethod
-    def from_dict(data: dict) -> SubscriptionScheduledChange:
+    def from_dict(data: dict[str, Any]) -> SubscriptionScheduledChange:
         return SubscriptionScheduledChange(
             action=SubscriptionScheduledChangeAction(data["action"]),
             effective_at=datetime.fromisoformat(data["effective_at"]),

--- a/paddle_billing/Notifications/Entities/Transaction.py
+++ b/paddle_billing/Notifications/Entities/Transaction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Entity import Entity
 from paddle_billing.Notifications.Entities.Shared import (
@@ -46,7 +47,7 @@ class Transaction(Entity):
     revised_at: datetime | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Transaction:
+    def from_dict(data: dict[str, Any]) -> Transaction:
         return Transaction(
             address_id=data.get("address_id"),
             business_id=data.get("business_id"),

--- a/paddle_billing/Notifications/Entities/Transactions/TransactionAdjustmentsTotals.py
+++ b/paddle_billing/Notifications/Entities/Transactions/TransactionAdjustmentsTotals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Shared.CurrencyCode import CurrencyCode
 
@@ -17,7 +18,7 @@ class TransactionAdjustmentsTotals:
     currency_code: CurrencyCode
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionAdjustmentsTotals:
+    def from_dict(data: dict[str, Any]) -> TransactionAdjustmentsTotals:
         return TransactionAdjustmentsTotals(
             subtotal=data["subtotal"],
             tax=data["tax"],

--- a/paddle_billing/Notifications/Entities/Transactions/TransactionBreakdown.py
+++ b/paddle_billing/Notifications/Entities/Transactions/TransactionBreakdown.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -9,7 +10,7 @@ class TransactionBreakdown:
     chargeback: str
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionBreakdown:
+    def from_dict(data: dict[str, Any]) -> TransactionBreakdown:
         return TransactionBreakdown(
             credit=data["credit"],
             refund=data["refund"],

--- a/paddle_billing/Notifications/Entities/Transactions/TransactionDetails.py
+++ b/paddle_billing/Notifications/Entities/Transactions/TransactionDetails.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Json import json_format_properties
 
@@ -23,7 +24,7 @@ class TransactionDetails:
     lineItems: list[TransactionLineItem]
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionDetails:
+    def from_dict(data: dict[str, Any]) -> TransactionDetails:
         return TransactionDetails(
             totals=TransactionTotals.from_dict(data["totals"]),
             tax_rates_used=[TaxRatesUsed.from_dict(tax_rate_used) for tax_rate_used in data["tax_rates_used"]],

--- a/paddle_billing/Notifications/Entities/Transactions/TransactionItem.py
+++ b/paddle_billing/Notifications/Entities/Transactions/TransactionItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Price import Price
 
@@ -16,7 +17,7 @@ class TransactionItem:
     proration: Proration | None
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionItem:
+    def from_dict(data: dict[str, Any]) -> TransactionItem:
         return TransactionItem(
             price_id=data.get("price_id"),
             price=Price.from_dict(data["price"]),

--- a/paddle_billing/Notifications/Entities/Transactions/TransactionLineItem.py
+++ b/paddle_billing/Notifications/Entities/Transactions/TransactionLineItem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Any
 
 from paddle_billing.Notifications.Entities.Product import Product
 
@@ -20,7 +21,7 @@ class TransactionLineItem:
     product: Product
 
     @staticmethod
-    def from_dict(data: dict) -> TransactionLineItem:
+    def from_dict(data: dict[str, Any]) -> TransactionLineItem:
         return TransactionLineItem(
             id=data["id"],
             price_id=data["price_id"],

--- a/paddle_billing/Notifications/Entities/UndefinedEntity.py
+++ b/paddle_billing/Notifications/Entities/UndefinedEntity.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
+from typing import Any
 from paddle_billing.Notifications.Entities.EntityDict import EntityDict
 
 
 class UndefinedEntity(EntityDict):
     def __init__(
         self,
-        data: dict,
+        data: dict[Any, Any],
     ):
         self._data = data
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[Any, Any]:
         return self._data

--- a/paddle_billing/Notifications/PaddleSignature.py
+++ b/paddle_billing/Notifications/PaddleSignature.py
@@ -26,7 +26,7 @@ class PaddleSignature:
         return "ts"
 
     @staticmethod
-    def parse(signature_header: str) -> tuple:
+    def parse(signature_header: str) -> tuple[int, dict[str, list[str]]]:
         """
         Parse the Paddle-Signature header to extract the timestamp and signature
 
@@ -62,7 +62,9 @@ class PaddleSignature:
 
         return compare_digest(generated_signature, signature)
 
-    def __do_verify(self, timestamp: str, signatures: list[str], raw_body: str, secret_key: Secret) -> bool:
+    def __do_verify(
+        self, timestamp: int, signatures: list[str], raw_body: str, secret_key: Secret | list[Secret]
+    ) -> bool:
         """
         Verifies an individual secret key against a Paddle-Signature header.
         Called by PaddleSignature.verify()

--- a/paddle_billing/Notifications/Verifier.py
+++ b/paddle_billing/Notifications/Verifier.py
@@ -49,4 +49,7 @@ class Verifier:
         elif hasattr(request, "data"):
             raw_body = request.data.decode("utf-8")
 
+        if not isinstance(raw_body, str):
+            raise ValueError("raw_body is not instance of str.")
+
         return self.paddle_signature.verify(signature_header, raw_body, secrets)

--- a/paddle_billing/PaddleStrEnum.py
+++ b/paddle_billing/PaddleStrEnum.py
@@ -30,8 +30,8 @@ class PaddleStrEnumMeta(type):
 
 
 class PaddleStrEnum:
-    value = None
-    name = None
+    value: str
+    name: str | None = None
 
     _members = None
     _iter_index = 0

--- a/paddle_billing/PaddleStrEnum.py
+++ b/paddle_billing/PaddleStrEnum.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 def _is_dunder(name):
     """
     Returns True if a __dunder__ name, False otherwise.
@@ -38,7 +41,7 @@ class PaddleStrEnum:
 
     _unknown_name = "Undefined"
 
-    def __init__(self, value) -> None:
+    def __init__(self, value: Any) -> None:
         members = self.members()
         try:
             search = list(members.values()).index(value)
@@ -52,7 +55,7 @@ class PaddleStrEnum:
         self._iter_index = 0
         return self
 
-    def __next__(self) -> tuple:
+    def __next__(self) -> tuple[str, "PaddleStrEnum"]:
         members = self.members()
 
         if self._iter_index >= len(members):
@@ -80,7 +83,7 @@ class PaddleStrEnum:
         return False
 
     @classmethod
-    def members(cls) -> dict:
+    def members(cls) -> dict[str, Any]:
         if not cls._members:
             members = dict(filter(lambda item: not item[0].startswith("__"), cls.__dict__.items()))
             cls._members = dict(zip(members.keys(), members.values()))

--- a/paddle_billing/RecursivelyRemoveKey.py
+++ b/paddle_billing/RecursivelyRemoveKey.py
@@ -1,4 +1,7 @@
-def recursively_remove_key(data: list | dict | None, key_to_remove: str):
+from typing import Any
+
+
+def recursively_remove_key(data: list[Any] | dict[Any, Any] | None, key_to_remove: str):
     """Remove key recursively from a dict or list"""
 
     if data is None:

--- a/paddle_billing/Resources/Addresses/AddressesClient.py
+++ b/paddle_billing/Resources/Addresses/AddressesClient.py
@@ -17,7 +17,7 @@ class AddressesClient:
         self.client = client
         self.response = None
 
-    def list(self, customer_id: str, operation: ListAddresses = None) -> AddressCollection:
+    def list(self, customer_id: str, operation: ListAddresses | None = None) -> AddressCollection:
         if operation is None:
             operation = ListAddresses()
 
@@ -25,26 +25,26 @@ class AddressesClient:
         parser = ResponseParser(self.response)
 
         return AddressCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), AddressCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), AddressCollection)
         )
 
     def get(self, customer_id: str, address_id: str) -> Address:
         self.response = self.client.get_raw(f"/customers/{customer_id}/addresses/{address_id}")
         parser = ResponseParser(self.response)
 
-        return Address.from_dict(parser.get_data())
+        return Address.from_dict(parser.get_dict())
 
     def create(self, customer_id: str, operation: CreateAddress) -> Address:
         self.response = self.client.post_raw(f"/customers/{customer_id}/addresses", operation)
         parser = ResponseParser(self.response)
 
-        return Address.from_dict(parser.get_data())
+        return Address.from_dict(parser.get_dict())
 
     def update(self, customer_id: str, address_id: str, operation: UpdateAddress) -> Address:
         self.response = self.client.patch_raw(f"/customers/{customer_id}/addresses/{address_id}", operation)
         parser = ResponseParser(self.response)
 
-        return Address.from_dict(parser.get_data())
+        return Address.from_dict(parser.get_dict())
 
     def archive(self, customer_id: str, address_id: str) -> Address:
         return self.update(customer_id, address_id, UpdateAddress(status=Status.Archived))

--- a/paddle_billing/Resources/Addresses/Operations/ListAddresses.py
+++ b/paddle_billing/Resources/Addresses/Operations/ListAddresses.py
@@ -27,7 +27,7 @@ class ListAddresses(HasParameters):
         if any(not isinstance(status, Status) for status in self.statuses):
             raise InvalidArgumentException.array_contains_invalid_types("statuses", Status.__name__)
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/Adjustments/AdjustmentsClient.py
+++ b/paddle_billing/Resources/Adjustments/AdjustmentsClient.py
@@ -17,7 +17,7 @@ class AdjustmentsClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListAdjustments = None) -> AdjustmentCollection:
+    def list(self, operation: ListAdjustments | None = None) -> AdjustmentCollection:
         if operation is None:
             operation = ListAdjustments()
 
@@ -25,17 +25,17 @@ class AdjustmentsClient:
         parser = ResponseParser(self.response)
 
         return AdjustmentCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), AdjustmentCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), AdjustmentCollection)
         )
 
     def create(self, operation: CreateAdjustment) -> Adjustment:
         self.response = self.client.post_raw("/adjustments", operation)
         parser = ResponseParser(self.response)
 
-        return Adjustment.from_dict(parser.get_data())
+        return Adjustment.from_dict(parser.get_dict())
 
-    def get_credit_note(self, adjustment_id: str, operation: GetCreditNote = None) -> AdjustmentCreditNote:
+    def get_credit_note(self, adjustment_id: str, operation: GetCreditNote | None = None) -> AdjustmentCreditNote:
         self.response = self.client.get_raw(f"/adjustments/{adjustment_id}/credit-note", operation)
         parser = ResponseParser(self.response)
 
-        return AdjustmentCreditNote.from_dict(parser.get_data())
+        return AdjustmentCreditNote.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/Adjustments/Operations/GetCreditNote.py
+++ b/paddle_billing/Resources/Adjustments/Operations/GetCreditNote.py
@@ -10,7 +10,7 @@ class GetCreditNote(HasParameters):
     ):
         self.disposition = disposition
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
 
         if self.disposition:

--- a/paddle_billing/Resources/Adjustments/Operations/ListAdjustments.py
+++ b/paddle_billing/Resources/Adjustments/Operations/ListAdjustments.py
@@ -12,11 +12,11 @@ class ListAdjustments(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        ids: list[str] = None,
-        statuses: list[AdjustmentStatus] = None,
-        customer_ids: list[str] = None,
-        transaction_ids: list[str] = None,
-        subscription_ids: list[str] = None,
+        ids: list[str] | None = None,
+        statuses: list[AdjustmentStatus] | None = None,
+        customer_ids: list[str] | None = None,
+        transaction_ids: list[str] | None = None,
+        subscription_ids: list[str] | None = None,
         action: Action | None = None,
     ):
         self.pager = pager
@@ -41,7 +41,7 @@ class ListAdjustments(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/Businesses/BusinessesClient.py
+++ b/paddle_billing/Resources/Businesses/BusinessesClient.py
@@ -17,7 +17,7 @@ class BusinessesClient:
         self.client = client
         self.response = None
 
-    def list(self, customer_id: str, operation: ListBusinesses = None) -> BusinessCollection:
+    def list(self, customer_id: str, operation: ListBusinesses | None = None) -> BusinessCollection:
         if operation is None:
             operation = ListBusinesses()
 
@@ -25,26 +25,26 @@ class BusinessesClient:
         parser = ResponseParser(self.response)
 
         return BusinessCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), BusinessCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), BusinessCollection)
         )
 
     def get(self, customer_id: str, business_id: str) -> Business:
         self.response = self.client.get_raw(f"/customers/{customer_id}/businesses/{business_id}")
         parser = ResponseParser(self.response)
 
-        return Business.from_dict(parser.get_data())
+        return Business.from_dict(parser.get_dict())
 
     def create(self, customer_id: str, operation: CreateBusiness) -> Business:
         self.response = self.client.post_raw(f"/customers/{customer_id}/businesses", operation)
         parser = ResponseParser(self.response)
 
-        return Business.from_dict(parser.get_data())
+        return Business.from_dict(parser.get_dict())
 
     def update(self, customer_id: str, business_id: str, operation: UpdateBusiness) -> Business:
         self.response = self.client.patch_raw(f"/customers/{customer_id}/businesses/{business_id}", operation)
         parser = ResponseParser(self.response)
 
-        return Business.from_dict(parser.get_data())
+        return Business.from_dict(parser.get_dict())
 
     def archive(self, customer_id: str, business_id: str) -> Business:
         return self.update(customer_id, business_id, UpdateBusiness(status=Status.Archived))

--- a/paddle_billing/Resources/Businesses/Operations/ListBusinesses.py
+++ b/paddle_billing/Resources/Businesses/Operations/ListBusinesses.py
@@ -12,8 +12,8 @@ class ListBusinesses(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        ids: list[str] = None,
-        statuses: list[Status] = None,
+        ids: list[str] | None = None,
+        statuses: list[Status] | None = None,
         search: str | None = None,
     ):
         self.pager = pager
@@ -32,7 +32,7 @@ class ListBusinesses(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/CustomerPortalSessions/CustomerPortalSessionsClient.py
+++ b/paddle_billing/Resources/CustomerPortalSessions/CustomerPortalSessionsClient.py
@@ -21,4 +21,4 @@ class CustomerPortalSessionsClient:
         self.response = self.client.post_raw(f"/customers/{customer_id}/portal-sessions", operation)
         parser = ResponseParser(self.response)
 
-        return CustomerPortalSession.from_dict(parser.get_data())
+        return CustomerPortalSession.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/Customers/CustomersClient.py
+++ b/paddle_billing/Resources/Customers/CustomersClient.py
@@ -27,7 +27,7 @@ class CustomersClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListCustomers = None) -> CustomerCollection:
+    def list(self, operation: ListCustomers | None = None) -> CustomerCollection:
         if operation is None:
             operation = ListCustomers()
 
@@ -35,41 +35,41 @@ class CustomersClient:
         parser = ResponseParser(self.response)
 
         return CustomerCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), CustomerCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), CustomerCollection)
         )
 
     def get(self, customer_id: str) -> Customer:
         self.response = self.client.get_raw(f"/customers/{customer_id}")
         parser = ResponseParser(self.response)
 
-        return Customer.from_dict(parser.get_data())
+        return Customer.from_dict(parser.get_dict())
 
     def create(self, operation: CreateCustomer) -> Customer:
         self.response = self.client.post_raw("/customers", operation)
         parser = ResponseParser(self.response)
 
-        return Customer.from_dict(parser.get_data())
+        return Customer.from_dict(parser.get_dict())
 
     def update(self, customer_id: str, operation: UpdateCustomer) -> Customer:
         self.response = self.client.patch_raw(f"/customers/{customer_id}", operation)
         parser = ResponseParser(self.response)
 
-        return Customer.from_dict(parser.get_data())
+        return Customer.from_dict(parser.get_dict())
 
     def archive(self, customer_id: str) -> Customer:
         return self.update(customer_id, UpdateCustomer(status=Status.Archived))
 
-    def credit_balances(self, customer_id: str, operation: ListCreditBalances = None) -> CreditBalanceCollection:
+    def credit_balances(self, customer_id: str, operation: ListCreditBalances | None = None) -> CreditBalanceCollection:
         if operation is None:
             operation = ListCreditBalances()
 
         self.response = self.client.get_raw(f"/customers/{customer_id}/credit-balances", operation)
         parser = ResponseParser(self.response)
 
-        return CreditBalanceCollection.from_list(parser.get_data())
+        return CreditBalanceCollection.from_list(parser.get_list())
 
     def create_auth_token(self, customer_id: str) -> CustomerAuthToken:
         self.response = self.client.post_raw(f"/customers/{customer_id}/auth-token")
         parser = ResponseParser(self.response)
 
-        return CustomerAuthToken.from_dict(parser.get_data())
+        return CustomerAuthToken.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/Customers/Operations/ListCreditBalances.py
+++ b/paddle_billing/Resources/Customers/Operations/ListCreditBalances.py
@@ -9,7 +9,7 @@ from paddle_billing.Exceptions.SdkExceptions.InvalidArgumentException import Inv
 class ListCreditBalances(HasParameters):
     def __init__(
         self,
-        currency_code: list[CurrencyCode] = None,
+        currency_code: list[CurrencyCode] | None = None,
     ):
         self.currency_code = currency_code if currency_code is not None else []
 
@@ -21,7 +21,7 @@ class ListCreditBalances(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.currency_code:
             parameters["currency_code"] = ",".join(map(enum_stringify, self.currency_code))

--- a/paddle_billing/Resources/Customers/Operations/ListCustomers.py
+++ b/paddle_billing/Resources/Customers/Operations/ListCustomers.py
@@ -12,10 +12,10 @@ class ListCustomers(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        ids: list[str] = None,
-        statuses: list[Status] = None,
+        ids: list[str] | None = None,
+        statuses: list[Status] | None = None,
         search: str | None = None,
-        emails: list[str] = None,
+        emails: list[str] | None = None,
     ):
         self.pager = pager
         self.search = search
@@ -35,7 +35,7 @@ class ListCustomers(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/Discounts/DiscountsClient.py
+++ b/paddle_billing/Resources/Discounts/DiscountsClient.py
@@ -17,7 +17,7 @@ class DiscountsClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListDiscounts = None) -> DiscountCollection:
+    def list(self, operation: ListDiscounts | None = None) -> DiscountCollection:
         if operation is None:
             operation = ListDiscounts()
 
@@ -25,26 +25,26 @@ class DiscountsClient:
         parser = ResponseParser(self.response)
 
         return DiscountCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), DiscountCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), DiscountCollection)
         )
 
     def get(self, discount_id: str) -> Discount:
         self.response = self.client.get_raw(f"/discounts/{discount_id}")
         parser = ResponseParser(self.response)
 
-        return Discount.from_dict(parser.get_data())
+        return Discount.from_dict(parser.get_dict())
 
     def create(self, operation: CreateDiscount) -> Discount:
         self.response = self.client.post_raw("/discounts", operation)
         parser = ResponseParser(self.response)
 
-        return Discount.from_dict(parser.get_data())
+        return Discount.from_dict(parser.get_dict())
 
     def update(self, discount_id: str, operation: UpdateDiscount) -> Discount:
         self.response = self.client.patch_raw(f"/discounts/{discount_id}", operation)
         parser = ResponseParser(self.response)
 
-        return Discount.from_dict(parser.get_data())
+        return Discount.from_dict(parser.get_dict())
 
     def archive(self, discount_id: str) -> Discount:
         return self.update(discount_id, UpdateDiscount(status=DiscountStatus.Archived))

--- a/paddle_billing/Resources/Discounts/Operations/ListDiscounts.py
+++ b/paddle_billing/Resources/Discounts/Operations/ListDiscounts.py
@@ -12,9 +12,9 @@ class ListDiscounts(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        ids: list[str] = None,
-        statuses: list[Status] = None,
-        codes: list[str] = None,
+        ids: list[str] | None = None,
+        statuses: list[Status] | None = None,
+        codes: list[str] | None = None,
     ):
         self.pager = pager
         self.ids = ids if ids is not None else []
@@ -33,7 +33,7 @@ class ListDiscounts(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/EventTypes/EventTypesClient.py
+++ b/paddle_billing/Resources/EventTypes/EventTypesClient.py
@@ -17,5 +17,5 @@ class EventTypesClient:
         parser = ResponseParser(self.response)
 
         return EventTypeCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), EventTypeCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), EventTypeCollection)
         )

--- a/paddle_billing/Resources/Events/EventsClient.py
+++ b/paddle_billing/Resources/Events/EventsClient.py
@@ -13,7 +13,7 @@ class EventsClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListEvents = None) -> EventCollection:
+    def list(self, operation: ListEvents | None = None) -> EventCollection:
         if operation is None:
             operation = ListEvents()
 
@@ -21,5 +21,5 @@ class EventsClient:
         parser = ResponseParser(self.response)
 
         return EventCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), EventCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), EventCollection)
         )

--- a/paddle_billing/Resources/Events/Operations/ListEvents.py
+++ b/paddle_billing/Resources/Events/Operations/ListEvents.py
@@ -7,5 +7,5 @@ class ListEvents(HasParameters):
     def __init__(self, pager: Pager | None = None):
         self.pager = pager
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         return self.pager.get_parameters() if self.pager else {}

--- a/paddle_billing/Resources/IPAddresses/IPAddressesClient.py
+++ b/paddle_billing/Resources/IPAddresses/IPAddressesClient.py
@@ -17,4 +17,4 @@ class IPAddressesClient:
         self.response = self.client.get_raw("/ips")
         parser = ResponseParser(self.response)
 
-        return IPAddresses.from_dict(parser.get_data())
+        return IPAddresses.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/NotificationLogs/NotificationLogsClient.py
+++ b/paddle_billing/Resources/NotificationLogs/NotificationLogsClient.py
@@ -13,7 +13,7 @@ class NotificationLogsClient:
         self.client = client
         self.response = None
 
-    def list(self, notification_id: str, operation: ListNotificationLogs = None) -> NotificationLogCollection:
+    def list(self, notification_id: str, operation: ListNotificationLogs | None = None) -> NotificationLogCollection:
         if operation is None:
             operation = ListNotificationLogs()
 
@@ -21,5 +21,5 @@ class NotificationLogsClient:
         parser = ResponseParser(self.response)
 
         return NotificationLogCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), NotificationLogCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), NotificationLogCollection)
         )

--- a/paddle_billing/Resources/NotificationLogs/Operations/ListNotificationLogs.py
+++ b/paddle_billing/Resources/NotificationLogs/Operations/ListNotificationLogs.py
@@ -6,5 +6,5 @@ class ListNotificationLogs(HasParameters):
     def __init__(self, pager: Pager | None = None):
         self.pager = pager
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         return self.pager.get_parameters() if self.pager else {}

--- a/paddle_billing/Resources/NotificationLogs/Operations/ListNotificationLogs.py
+++ b/paddle_billing/Resources/NotificationLogs/Operations/ListNotificationLogs.py
@@ -3,7 +3,7 @@ from paddle_billing.Resources.Shared.Operations import Pager
 
 
 class ListNotificationLogs(HasParameters):
-    def __init__(self, pager: Pager = None):
+    def __init__(self, pager: Pager | None = None):
         self.pager = pager
 
     def get_parameters(self) -> dict:

--- a/paddle_billing/Resources/NotificationSettings/NotificationSettingsClient.py
+++ b/paddle_billing/Resources/NotificationSettings/NotificationSettingsClient.py
@@ -28,7 +28,7 @@ class NotificationSettingsClient:
         parser = ResponseParser(self.response)
 
         return NotificationSettingCollection.from_list(
-            parser.get_data(),
+            parser.get_list(),
             Paginator(self.client, parser.get_pagination(), NotificationSettingCollection),
         )
 
@@ -36,19 +36,19 @@ class NotificationSettingsClient:
         self.response = self.client.get_raw(f"/notification-settings/{notification_setting_id}")
         parser = ResponseParser(self.response)
 
-        return NotificationSetting.from_dict(parser.get_data())
+        return NotificationSetting.from_dict(parser.get_dict())
 
     def create(self, operation: CreateNotificationSetting) -> NotificationSetting:
         self.response = self.client.post_raw("/notification-settings", operation)
         parser = ResponseParser(self.response)
 
-        return NotificationSetting.from_dict(parser.get_data())
+        return NotificationSetting.from_dict(parser.get_dict())
 
     def update(self, notification_setting_id: str, operation: UpdateNotificationSetting) -> NotificationSetting:
         self.response = self.client.patch_raw(f"/notification-settings/{notification_setting_id}", operation)
         parser = ResponseParser(self.response)
 
-        return NotificationSetting.from_dict(parser.get_data())
+        return NotificationSetting.from_dict(parser.get_dict())
 
     def delete(self, notification_setting_id: str) -> None:
         self.client.delete_raw(f"/notification-settings/{notification_setting_id}")

--- a/paddle_billing/Resources/NotificationSettings/Operations/ListNotificationSettings.py
+++ b/paddle_billing/Resources/NotificationSettings/Operations/ListNotificationSettings.py
@@ -16,7 +16,7 @@ class ListNotificationSettings(HasParameters):
         self.active = active
         self.traffic_source = traffic_source
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/Notifications/NotificationsClient.py
+++ b/paddle_billing/Resources/Notifications/NotificationsClient.py
@@ -16,7 +16,7 @@ class NotificationsClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListNotifications = None) -> NotificationCollection:
+    def list(self, operation: ListNotifications | None = None) -> NotificationCollection:
         if operation is None:
             operation = ListNotifications()
 
@@ -24,14 +24,14 @@ class NotificationsClient:
         parser = ResponseParser(self.response)
 
         return NotificationCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), NotificationCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), NotificationCollection)
         )
 
     def get(self, notification_id: str) -> Notification:
         self.response = self.client.get_raw(f"/notifications/{notification_id}")
         parser = ResponseParser(self.response)
 
-        return Notification.from_dict(parser.get_data())
+        return Notification.from_dict(parser.get_dict())
 
     def replay(self, notification_id: str) -> str:
         self.response = self.client.post_raw(f"/notifications/{notification_id}/replay")

--- a/paddle_billing/Resources/Notifications/Operations/ListNotifications.py
+++ b/paddle_billing/Resources/Notifications/Operations/ListNotifications.py
@@ -13,9 +13,9 @@ class ListNotifications(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        notification_setting_ids: list[str] = None,
+        notification_setting_ids: list[str] | None = None,
         search: str | None = None,
-        statuses: list[NotificationStatus] = None,
+        statuses: list[NotificationStatus] | None = None,
         filter: str | None = None,
         end: DateTime | None = None,
         start: DateTime | None = None,

--- a/paddle_billing/Resources/Notifications/Operations/ListNotifications.py
+++ b/paddle_billing/Resources/Notifications/Operations/ListNotifications.py
@@ -39,7 +39,7 @@ class ListNotifications(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/PaymentMethods/Operations/ListPaymentMethods.py
+++ b/paddle_billing/Resources/PaymentMethods/Operations/ListPaymentMethods.py
@@ -7,8 +7,8 @@ class ListPaymentMethods(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        address_ids: list[str] = None,
-        supports_checkout: bool = None,
+        address_ids: list[str] | None = None,
+        supports_checkout: bool | None = None,
     ):
         self.pager = pager
         self.address_ids = address_ids

--- a/paddle_billing/Resources/PaymentMethods/Operations/ListPaymentMethods.py
+++ b/paddle_billing/Resources/PaymentMethods/Operations/ListPaymentMethods.py
@@ -20,7 +20,7 @@ class ListPaymentMethods(HasParameters):
             if invalid_items:
                 raise InvalidArgumentException.array_contains_invalid_types("ids", str.__name__, invalid_items)
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/PaymentMethods/PaymentMethodsClient.py
+++ b/paddle_billing/Resources/PaymentMethods/PaymentMethodsClient.py
@@ -21,7 +21,7 @@ class PaymentMethodsClient:
         self.client = client
         self.response = None
 
-    def list(self, customer_id: str, operation: ListPaymentMethods = None) -> PaymentMethodCollection:
+    def list(self, customer_id: str, operation: ListPaymentMethods | None = None) -> PaymentMethodCollection:
         if operation is None:
             operation = ListPaymentMethods()
 
@@ -29,7 +29,7 @@ class PaymentMethodsClient:
         parser = ResponseParser(self.response)
 
         return PaymentMethodCollection.from_list(
-            parser.get_data(),
+            parser.get_list(),
             Paginator(self.client, parser.get_pagination(), PaymentMethodCollection),
         )
 
@@ -37,7 +37,7 @@ class PaymentMethodsClient:
         self.response = self.client.get_raw(f"/customers/{customer_id}/payment-methods/{payment_method_id}")
         parser = ResponseParser(self.response)
 
-        return PaymentMethod.from_dict(parser.get_data())
+        return PaymentMethod.from_dict(parser.get_dict())
 
     def delete(self, customer_id: str, payment_method_id: str) -> None:
         self.response = self.client.delete_raw(f"/customers/{customer_id}/payment-methods/{payment_method_id}")

--- a/paddle_billing/Resources/Prices/Operations/ListPrices.py
+++ b/paddle_billing/Resources/Prices/Operations/ListPrices.py
@@ -42,7 +42,7 @@ class ListPrices(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/Prices/Operations/ListPrices.py
+++ b/paddle_billing/Resources/Prices/Operations/ListPrices.py
@@ -13,11 +13,11 @@ class ListPrices(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        includes: list[PriceIncludes] = None,
-        ids: list[str] = None,
-        types: list[CatalogType] = None,
-        product_ids: list[str] = None,
-        statuses: list[Status] = None,
+        includes: list[PriceIncludes] | None = None,
+        ids: list[str] | None = None,
+        types: list[CatalogType] | None = None,
+        product_ids: list[str] | None = None,
+        statuses: list[Status] | None = None,
         recurring: bool | None = None,
     ):
         self.pager = pager

--- a/paddle_billing/Resources/Prices/PricesClient.py
+++ b/paddle_billing/Resources/Prices/PricesClient.py
@@ -19,7 +19,7 @@ class PricesClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListPrices = None) -> PriceCollection:
+    def list(self, operation: ListPrices | None = None) -> PriceCollection:
         if operation is None:
             operation = ListPrices()
 
@@ -27,7 +27,7 @@ class PricesClient:
         parser = ResponseParser(self.response)
 
         return PriceCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), PriceCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), PriceCollection)
         )
 
     def get(self, price_id: str, includes=None) -> Price:
@@ -44,19 +44,19 @@ class PricesClient:
         self.response = self.client.get_raw(f"/prices/{price_id}", params)
         parser = ResponseParser(self.response)
 
-        return Price.from_dict(parser.get_data())
+        return Price.from_dict(parser.get_dict())
 
     def create(self, operation: CreatePrice) -> Price:
         self.response = self.client.post_raw("/prices", operation)
         parser = ResponseParser(self.response)
 
-        return Price.from_dict(parser.get_data())
+        return Price.from_dict(parser.get_dict())
 
     def update(self, price_id: str, operation: UpdatePrice) -> Price:
         self.response = self.client.patch_raw(f"/prices/{price_id}", operation)
         parser = ResponseParser(self.response)
 
-        return Price.from_dict(parser.get_data())
+        return Price.from_dict(parser.get_dict())
 
     def archive(self, price_id: str) -> Price:
         return self.update(price_id, UpdatePrice(status=Status.Archived))

--- a/paddle_billing/Resources/PricingPreviews/PricingPreviewsClient.py
+++ b/paddle_billing/Resources/PricingPreviews/PricingPreviewsClient.py
@@ -17,4 +17,4 @@ class PricingPreviewsClient:
         self.response = self.client.post_raw("/pricing-preview", operation)
         parser = ResponseParser(self.response)
 
-        return PricePreview.from_dict(parser.get_data())
+        return PricePreview.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/Products/Operations/ListProducts.py
+++ b/paddle_billing/Resources/Products/Operations/ListProducts.py
@@ -42,7 +42,7 @@ class ListProducts(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/Products/Operations/ListProducts.py
+++ b/paddle_billing/Resources/Products/Operations/ListProducts.py
@@ -13,12 +13,12 @@ class ListProducts(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        includes: list[ProductIncludes] = None,
-        ids: list[str] = None,
-        types: list[CatalogType] = None,
-        product_ids: list[str] = None,
-        statuses: list[Status] = None,
-        tax_categories: list[TaxCategory] = None,
+        includes: list[ProductIncludes] | None = None,
+        ids: list[str] | None = None,
+        types: list[CatalogType] | None = None,
+        product_ids: list[str] | None = None,
+        statuses: list[Status] | None = None,
+        tax_categories: list[TaxCategory] | None = None,
     ):
         self.pager = pager
         self.includes = includes if includes is not None else []

--- a/paddle_billing/Resources/Products/ProductsClient.py
+++ b/paddle_billing/Resources/Products/ProductsClient.py
@@ -19,7 +19,7 @@ class ProductsClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListProducts = None) -> ProductCollection:
+    def list(self, operation: ListProducts | None = None) -> ProductCollection:
         if operation is None:
             operation = ListProducts()
 
@@ -27,7 +27,7 @@ class ProductsClient:
         parser = ResponseParser(self.response)
 
         return ProductCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), ProductCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), ProductCollection)
         )
 
     def get(self, product_id: str, includes=None) -> Product | Product:
@@ -49,19 +49,19 @@ class ProductsClient:
         self.response = self.client.get_raw(f"/products/{product_id}", params)
         parser = ResponseParser(self.response)
 
-        return Product.from_dict(parser.get_data())
+        return Product.from_dict(parser.get_dict())
 
     def create(self, operation: CreateProduct) -> Product:
         self.response = self.client.post_raw("/products", operation)
         parser = ResponseParser(self.response)
 
-        return Product.from_dict(parser.get_data())
+        return Product.from_dict(parser.get_dict())
 
     def update(self, product_id: str, operation: UpdateProduct) -> Product:
         self.response = self.client.patch_raw(f"/products/{product_id}", operation)
         parser = ResponseParser(self.response)
 
-        return Product.from_dict(parser.get_data())
+        return Product.from_dict(parser.get_dict())
 
     def archive(self, product_id: str) -> Product:
         return self.update(product_id, UpdateProduct(status=Status.Archived))

--- a/paddle_billing/Resources/Reports/Operations/CreateAdjustmentsReport.py
+++ b/paddle_billing/Resources/Reports/Operations/CreateAdjustmentsReport.py
@@ -22,7 +22,9 @@ class CreateAdjustmentsReport(CreateReport):
     )
 
     @staticmethod
-    def get_allowed_filters() -> tuple:
+    def get_allowed_filters() -> (
+        tuple[AdjustmentActionFilter, AdjustmentStatusFilter, CurrencyCodeFilter, UpdatedAtFilter]
+    ):
         return (
             AdjustmentActionFilter,
             AdjustmentStatusFilter,

--- a/paddle_billing/Resources/Reports/Operations/CreateDiscountsReport.py
+++ b/paddle_billing/Resources/Reports/Operations/CreateDiscountsReport.py
@@ -19,7 +19,7 @@ class CreateDiscountsReport(CreateReport):
     filters: list[DiscountStatusFilter | DiscountTypeFilter | UpdatedAtFilter] = field(default_factory=list)
 
     @staticmethod
-    def get_allowed_filters() -> tuple:
+    def get_allowed_filters() -> tuple[DiscountStatusFilter, DiscountTypeFilter, UpdatedAtFilter]:
         return (
             DiscountStatusFilter,
             DiscountTypeFilter,

--- a/paddle_billing/Resources/Reports/Operations/CreateProductsAndPricesReport.py
+++ b/paddle_billing/Resources/Reports/Operations/CreateProductsAndPricesReport.py
@@ -29,7 +29,9 @@ class CreateProductsAndPricesReport(CreateReport):
     ] = field(default_factory=list)
 
     @staticmethod
-    def get_allowed_filters() -> tuple:
+    def get_allowed_filters() -> (
+        tuple[PriceStatusFilter, PriceTypeFilter, PriceUpdatedAtFilter, ProductStatusFilter, ProductUpdatedAtFilter]
+    ):
         return (
             PriceStatusFilter,
             PriceTypeFilter,

--- a/paddle_billing/Resources/Reports/Operations/CreateReport.py
+++ b/paddle_billing/Resources/Reports/Operations/CreateReport.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from abc import ABC, abstractmethod
+from typing import Any
 
 from paddle_billing.Operation import Operation
 
@@ -23,8 +24,8 @@ class CreateReport(Operation, ABC):
 
             raise InvalidArgumentException.array_contains_invalid_types("filters", allowed_type_names, invalid_items)
 
-    def to_json(self) -> dict:
-        parameters = {"type": self.type}
+    def to_json(self) -> dict[str, Any]:
+        parameters: dict[str, Any] = {"type": self.type}
 
         if self.filters is not None and self.filters != []:
             parameters.update({"filters": [filter_ for filter_ in self.filters]})

--- a/paddle_billing/Resources/Reports/Operations/CreateReport.py
+++ b/paddle_billing/Resources/Reports/Operations/CreateReport.py
@@ -34,5 +34,5 @@ class CreateReport(Operation, ABC):
 
     @staticmethod
     @abstractmethod
-    def get_allowed_filters() -> tuple:
+    def get_allowed_filters() -> tuple[Any]:
         pass

--- a/paddle_billing/Resources/Reports/Operations/CreateTransactionsReport.py
+++ b/paddle_billing/Resources/Reports/Operations/CreateTransactionsReport.py
@@ -23,7 +23,11 @@ class CreateTransactionsReport(CreateReport):
     ] = field(default_factory=list)
 
     @staticmethod
-    def get_allowed_filters() -> tuple:
+    def get_allowed_filters() -> (
+        tuple[
+            CollectionModeFilter, CurrencyCodeFilter, TransactionOriginFilter, TransactionStatusFilter, UpdatedAtFilter
+        ]
+    ):
         return (
             CollectionModeFilter,
             CurrencyCodeFilter,

--- a/paddle_billing/Resources/Reports/Operations/Filters/Filter.py
+++ b/paddle_billing/Resources/Reports/Operations/Filters/Filter.py
@@ -9,7 +9,7 @@ from paddle_billing.Entities.Reports import ReportFilterName
 
 @dataclass
 class Filter(ABC):
-    def to_json(self) -> dict:
+    def to_json(self) -> dict[str, str | list[str] | ReportFilterName | ReportFilterOperator | None]:
         return {
             "name": self.get_name(),
             "operator": self.get_operator(),

--- a/paddle_billing/Resources/Reports/Operations/ListReports.py
+++ b/paddle_billing/Resources/Reports/Operations/ListReports.py
@@ -12,7 +12,7 @@ class ListReports(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        statuses: list[ReportStatus] = None,
+        statuses: list[ReportStatus] | None = None,
     ):
         self.pager = pager
         self.statuses = statuses if statuses is not None else []

--- a/paddle_billing/Resources/Reports/Operations/ListReports.py
+++ b/paddle_billing/Resources/Reports/Operations/ListReports.py
@@ -25,7 +25,7 @@ class ListReports(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/Reports/ReportsClient.py
+++ b/paddle_billing/Resources/Reports/ReportsClient.py
@@ -4,7 +4,8 @@ from paddle_billing.Entities.Report import Report
 from paddle_billing.Entities.ReportCSV import ReportCSV
 from paddle_billing.Entities.Collections import Paginator, ReportCollection
 
-from paddle_billing.Resources.Reports.Operations import CreateReport, ListReports
+from paddle_billing.Resources.Reports.Operations import ListReports
+from paddle_billing.Resources.Reports.Operations.CreateReport import Operation
 
 from typing import TYPE_CHECKING
 
@@ -40,7 +41,7 @@ class ReportsClient:
 
         return ReportCSV.from_dict(parser.get_data())
 
-    def create(self, operation: CreateReport) -> Report:
+    def create(self, operation: Operation) -> Report:
         self.response = self.client.post_raw("/reports", operation)
         parser = ResponseParser(self.response)
 

--- a/paddle_billing/Resources/Reports/ReportsClient.py
+++ b/paddle_billing/Resources/Reports/ReportsClient.py
@@ -18,7 +18,7 @@ class ReportsClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListReports = None) -> ReportCollection:
+    def list(self, operation: ListReports | None = None) -> ReportCollection:
         if operation is None:
             operation = ListReports()
 
@@ -26,23 +26,23 @@ class ReportsClient:
         parser = ResponseParser(self.response)
 
         return ReportCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), ReportCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), ReportCollection)
         )
 
     def get(self, report_id: str) -> Report:
         self.response = self.client.get_raw(f"/reports/{report_id}")
         parser = ResponseParser(self.response)
 
-        return Report.from_dict(parser.get_data())
+        return Report.from_dict(parser.get_dict())
 
     def get_report_csv(self, report_id: str) -> ReportCSV:
         self.response = self.client.get_raw(f"/reports/{report_id}/download-url")
         parser = ResponseParser(self.response)
 
-        return ReportCSV.from_dict(parser.get_data())
+        return ReportCSV.from_dict(parser.get_dict())
 
     def create(self, operation: Operation) -> Report:
         self.response = self.client.post_raw("/reports", operation)
         parser = ResponseParser(self.response)
 
-        return Report.from_dict(parser.get_data())
+        return Report.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/Shared/Operations/List/Pager.py
+++ b/paddle_billing/Resources/Shared/Operations/List/Pager.py
@@ -15,7 +15,7 @@ class Pager(HasParameters):
         self.order_by = order_by if order_by is not None else OrderBy.id_ascending()
         self.per_page = per_page
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         return FiltersNone.filter_none_values(
             {"after": self.after, "order_by": str(self.order_by), "per_page": self.per_page}
         )

--- a/paddle_billing/Resources/SimulationRunEvents/Operations/ListSimulationRunEvents.py
+++ b/paddle_billing/Resources/SimulationRunEvents/Operations/ListSimulationRunEvents.py
@@ -22,7 +22,7 @@ class ListSimulationRunEvents(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/SimulationRunEvents/Operations/ListSimulationRunEvents.py
+++ b/paddle_billing/Resources/SimulationRunEvents/Operations/ListSimulationRunEvents.py
@@ -7,7 +7,7 @@ class ListSimulationRunEvents(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        ids: list[str] = None,
+        ids: list[str] | None = None,
     ):
         self.pager = pager
         self.ids = ids if ids is not None else []

--- a/paddle_billing/Resources/SimulationRunEvents/SimulationRunEventsClient.py
+++ b/paddle_billing/Resources/SimulationRunEvents/SimulationRunEventsClient.py
@@ -16,7 +16,7 @@ class SimulationRunEventsClient:
         self.response = None
 
     def list(
-        self, simulation_id: str, simulation_run_id: str, operation: ListSimulationRunEvents = None
+        self, simulation_id: str, simulation_run_id: str, operation: ListSimulationRunEvents | None = None
     ) -> SimulationRunEventCollection:
         if operation is None:
             operation = ListSimulationRunEvents()
@@ -25,7 +25,7 @@ class SimulationRunEventsClient:
         parser = ResponseParser(self.response)
 
         return SimulationRunEventCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), SimulationRunEventCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), SimulationRunEventCollection)
         )
 
     def get(self, simulation_id: str, simulation_run_id: str, simulation_event_id: str) -> SimulationRunEvent:
@@ -34,7 +34,7 @@ class SimulationRunEventsClient:
         )
         parser = ResponseParser(self.response)
 
-        return SimulationRunEvent.from_dict(parser.get_data())
+        return SimulationRunEvent.from_dict(parser.get_dict())
 
     def replay(self, simulation_id: str, simulation_run_id: str, simulation_event_id: str) -> SimulationRunEvent:
         self.response = self.client.post_raw(
@@ -42,4 +42,4 @@ class SimulationRunEventsClient:
         )
         parser = ResponseParser(self.response)
 
-        return SimulationRunEvent.from_dict(parser.get_data())
+        return SimulationRunEvent.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/SimulationRuns/Operations/GetSimulationRun.py
+++ b/paddle_billing/Resources/SimulationRuns/Operations/GetSimulationRun.py
@@ -21,7 +21,7 @@ class GetSimulationRun(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.includes:
             parameters["include"] = ",".join(map(enum_stringify, self.includes))

--- a/paddle_billing/Resources/SimulationRuns/Operations/GetSimulationRun.py
+++ b/paddle_billing/Resources/SimulationRuns/Operations/GetSimulationRun.py
@@ -7,7 +7,7 @@ from paddle_billing.Resources.SimulationRuns.Operations.SimulationRunInclude imp
 class GetSimulationRun(HasParameters):
     def __init__(
         self,
-        includes: list[SimulationRunInclude] = None,
+        includes: list[SimulationRunInclude] | None = None,
     ):
         self.includes = includes if includes is not None else []
 

--- a/paddle_billing/Resources/SimulationRuns/Operations/ListSimulationRuns.py
+++ b/paddle_billing/Resources/SimulationRuns/Operations/ListSimulationRuns.py
@@ -27,7 +27,7 @@ class ListSimulationRuns(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/SimulationRuns/Operations/ListSimulationRuns.py
+++ b/paddle_billing/Resources/SimulationRuns/Operations/ListSimulationRuns.py
@@ -9,8 +9,8 @@ class ListSimulationRuns(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        ids: list[str] = None,
-        includes: list[SimulationRunInclude] = None,
+        ids: list[str] | None = None,
+        includes: list[SimulationRunInclude] | None = None,
     ):
         self.pager = pager
         self.ids = ids if ids is not None else []

--- a/paddle_billing/Resources/SimulationRuns/SimulationRunsClient.py
+++ b/paddle_billing/Resources/SimulationRuns/SimulationRunsClient.py
@@ -15,7 +15,7 @@ class SimulationRunsClient:
         self.client = client
         self.response = None
 
-    def list(self, simulation_id: str, operation: ListSimulationRuns = None) -> SimulationRunCollection:
+    def list(self, simulation_id: str, operation: ListSimulationRuns | None = None) -> SimulationRunCollection:
         if operation is None:
             operation = ListSimulationRuns()
 
@@ -23,20 +23,22 @@ class SimulationRunsClient:
         parser = ResponseParser(self.response)
 
         return SimulationRunCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), SimulationRunCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), SimulationRunCollection)
         )
 
-    def get(self, simulation_id: str, simulation_run_id: str, operation: GetSimulationRun = None) -> SimulationRun:
+    def get(
+        self, simulation_id: str, simulation_run_id: str, operation: GetSimulationRun | None = None
+    ) -> SimulationRun:
         if operation is None:
             operation = GetSimulationRun()
 
         self.response = self.client.get_raw(f"/simulations/{simulation_id}/runs/{simulation_run_id}", operation)
         parser = ResponseParser(self.response)
 
-        return SimulationRun.from_dict(parser.get_data())
+        return SimulationRun.from_dict(parser.get_dict())
 
     def create(self, simulation_id: str) -> SimulationRun:
         self.response = self.client.post_raw(f"/simulations/{simulation_id}/runs")
         parser = ResponseParser(self.response)
 
-        return SimulationRun.from_dict(parser.get_data())
+        return SimulationRun.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/SimulationTypes/SimulationTypesClient.py
+++ b/paddle_billing/Resources/SimulationTypes/SimulationTypesClient.py
@@ -16,4 +16,4 @@ class SimulationTypesClient:
         self.response = self.client.get_raw("/simulation-types")
         parser = ResponseParser(self.response)
 
-        return SimulationTypeCollection.from_list(parser.get_data())
+        return SimulationTypeCollection.from_list(parser.get_list())

--- a/paddle_billing/Resources/Simulations/Operations/ListSimulations.py
+++ b/paddle_billing/Resources/Simulations/Operations/ListSimulations.py
@@ -12,9 +12,9 @@ class ListSimulations(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        notification_setting_ids: list[str] = None,
-        ids: list[str] = None,
-        statuses: list[SimulationStatus] = None,
+        notification_setting_ids: list[str] | None = None,
+        ids: list[str] | None = None,
+        statuses: list[SimulationStatus] | None = None,
     ):
         self.pager = pager
         self.ids = ids if ids is not None else []

--- a/paddle_billing/Resources/Simulations/Operations/ListSimulations.py
+++ b/paddle_billing/Resources/Simulations/Operations/ListSimulations.py
@@ -33,7 +33,7 @@ class ListSimulations(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())

--- a/paddle_billing/Resources/Simulations/SimulationsClient.py
+++ b/paddle_billing/Resources/Simulations/SimulationsClient.py
@@ -15,7 +15,7 @@ class SimulationsClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListSimulations = None) -> SimulationCollection:
+    def list(self, operation: ListSimulations | None = None) -> SimulationCollection:
         if operation is None:
             operation = ListSimulations()
 
@@ -23,23 +23,23 @@ class SimulationsClient:
         parser = ResponseParser(self.response)
 
         return SimulationCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), SimulationCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), SimulationCollection)
         )
 
     def get(self, simulation_id: str) -> Simulation:
         self.response = self.client.get_raw(f"/simulations/{simulation_id}")
         parser = ResponseParser(self.response)
 
-        return Simulation.from_dict(parser.get_data())
+        return Simulation.from_dict(parser.get_dict())
 
     def create(self, operation: CreateSimulation) -> Simulation:
         self.response = self.client.post_raw("/simulations", operation)
         parser = ResponseParser(self.response)
 
-        return Simulation.from_dict(parser.get_data())
+        return Simulation.from_dict(parser.get_dict())
 
     def update(self, simulation_id: str, operation: UpdateSimulation) -> Simulation:
         self.response = self.client.patch_raw(f"/simulations/{simulation_id}", operation)
         parser = ResponseParser(self.response)
 
-        return Simulation.from_dict(parser.get_data())
+        return Simulation.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/Subscriptions/Operations/ListSubscriptions.py
+++ b/paddle_billing/Resources/Subscriptions/Operations/ListSubscriptions.py
@@ -45,8 +45,8 @@ class ListSubscriptions(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
-        parameters = self.pager.get_parameters() if self.pager else {}
+    def get_parameters(self) -> dict[str, str]:
+        parameters: dict[str, str | None] = self.pager.get_parameters() if self.pager else {}
         parameters.update(
             {
                 "address_id": ",".join(self.address_ids),

--- a/paddle_billing/Resources/Subscriptions/Operations/ListSubscriptions.py
+++ b/paddle_billing/Resources/Subscriptions/Operations/ListSubscriptions.py
@@ -13,13 +13,13 @@ class ListSubscriptions(HasParameters):
     def __init__(
         self,
         pager: Pager | None = None,
-        address_ids: list[str] = None,
+        address_ids: list[str] | None = None,
         collection_mode: CollectionMode | None = None,
-        customer_ids: list[str] = None,
-        ids: list[str] = None,
-        price_ids: list[str] = None,
-        scheduled_change_actions: list[SubscriptionScheduledChangeAction] = None,
-        statuses: list[SubscriptionStatus] = None,
+        customer_ids: list[str] | None = None,
+        ids: list[str] | None = None,
+        price_ids: list[str] | None = None,
+        scheduled_change_actions: list[SubscriptionScheduledChangeAction] | None = None,
+        statuses: list[SubscriptionStatus] | None = None,
     ):
         self.pager = pager
         self.collection_mode = collection_mode

--- a/paddle_billing/Resources/Subscriptions/SubscriptionsClient.py
+++ b/paddle_billing/Resources/Subscriptions/SubscriptionsClient.py
@@ -30,7 +30,7 @@ class SubscriptionsClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListSubscriptions = None) -> SubscriptionCollection:
+    def list(self, operation: ListSubscriptions | None = None) -> SubscriptionCollection:
         if operation is None:
             operation = ListSubscriptions()
 
@@ -38,7 +38,7 @@ class SubscriptionsClient:
         parser = ResponseParser(self.response)
 
         return SubscriptionCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), SubscriptionCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), SubscriptionCollection)
         )
 
     def get(self, subscription_id: str, includes=None) -> Subscription:
@@ -55,58 +55,58 @@ class SubscriptionsClient:
         self.response = self.client.get_raw(f"/subscriptions/{subscription_id}", params)
         parser = ResponseParser(self.response)
 
-        return Subscription.from_dict(parser.get_data())
+        return Subscription.from_dict(parser.get_dict())
 
     def update(self, subscription_id: str, operation: UpdateSubscription) -> Subscription:
         self.response = self.client.patch_raw(f"/subscriptions/{subscription_id}", operation)
         parser = ResponseParser(self.response)
 
-        return Subscription.from_dict(parser.get_data())
+        return Subscription.from_dict(parser.get_dict())
 
     def pause(self, subscription_id: str, operation: PauseSubscription) -> Subscription:
         self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/pause", operation)
         parser = ResponseParser(self.response)
 
-        return Subscription.from_dict(parser.get_data())
+        return Subscription.from_dict(parser.get_dict())
 
     def resume(self, subscription_id: str, operation: ResumeSubscription) -> Subscription:
         self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/resume", operation)
         parser = ResponseParser(self.response)
 
-        return Subscription.from_dict(parser.get_data())
+        return Subscription.from_dict(parser.get_dict())
 
     def cancel(self, subscription_id: str, operation: CancelSubscription) -> Subscription:
         self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/cancel", operation)
         parser = ResponseParser(self.response)
 
-        return Subscription.from_dict(parser.get_data())
+        return Subscription.from_dict(parser.get_dict())
 
     def get_payment_method_change_transaction(self, subscription_id: str) -> Transaction:
         self.response = self.client.get_raw(f"/subscriptions/{subscription_id}/update-payment-method-transaction")
         parser = ResponseParser(self.response)
 
-        return Transaction.from_dict(parser.get_data())
+        return Transaction.from_dict(parser.get_dict())
 
     def activate(self, subscription_id: str) -> Subscription:
         self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/activate")
         parser = ResponseParser(self.response)
 
-        return Subscription.from_dict(parser.get_data())
+        return Subscription.from_dict(parser.get_dict())
 
     def create_one_time_charge(self, subscription_id: str, operation: CreateOneTimeCharge) -> Subscription:
         self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/charge", operation)
         parser = ResponseParser(self.response)
 
-        return Subscription.from_dict(parser.get_data())
+        return Subscription.from_dict(parser.get_dict())
 
     def preview_update(self, subscription_id: str, operation: PreviewUpdateSubscription) -> SubscriptionPreview:
         self.response = self.client.patch_raw(f"/subscriptions/{subscription_id}/preview", operation)
         parser = ResponseParser(self.response)
 
-        return SubscriptionPreview.from_dict(parser.get_data())
+        return SubscriptionPreview.from_dict(parser.get_dict())
 
     def preview_one_time_charge(self, subscription_id: str, operation: PreviewOneTimeCharge) -> SubscriptionPreview:
         self.response = self.client.post_raw(f"/subscriptions/{subscription_id}/charge/preview", operation)
         parser = ResponseParser(self.response)
 
-        return SubscriptionPreview.from_dict(parser.get_data())
+        return SubscriptionPreview.from_dict(parser.get_dict())

--- a/paddle_billing/Resources/Transactions/Operations/GetTransactionInvoice.py
+++ b/paddle_billing/Resources/Transactions/Operations/GetTransactionInvoice.py
@@ -10,7 +10,7 @@ class GetTransactionInvoice(HasParameters):
     ):
         self.disposition = disposition
 
-    def get_parameters(self) -> dict:
+    def get_parameters(self) -> dict[str, str]:
         parameters = {}
 
         if self.disposition:

--- a/paddle_billing/Resources/Transactions/Operations/ListTransactions.py
+++ b/paddle_billing/Resources/Transactions/Operations/ListTransactions.py
@@ -18,13 +18,13 @@ class ListTransactions(HasParameters):
         collection_mode: CollectionMode | None = None,
         created_at: DateComparison | None = None,
         updated_at: DateComparison | None = None,
-        customer_ids: list[str] = None,
-        ids: list[str] = None,
-        includes: list[Includes] = None,
-        invoice_numbers: list[str] = None,
-        statuses: list[TransactionStatus] = None,
-        subscription_ids: list[str] = None,
-        origins: list[Origin] = None,
+        customer_ids: list[str] | None = None,
+        ids: list[str] | None = None,
+        includes: list[Includes] | None = None,
+        invoice_numbers: list[str] | None = None,
+        statuses: list[TransactionStatus] | None = None,
+        subscription_ids: list[str] | None = None,
+        origins: list[Origin] | None = None,
     ):
         self.pager = pager
         self.billed_at = billed_at

--- a/paddle_billing/Resources/Transactions/Operations/ListTransactions.py
+++ b/paddle_billing/Resources/Transactions/Operations/ListTransactions.py
@@ -55,8 +55,8 @@ class ListTransactions(HasParameters):
                     field_name, field_type.__name__, invalid_items
                 )
 
-    def get_parameters(self) -> dict:
-        parameters = {}
+    def get_parameters(self) -> dict[str, str]:
+        parameters: dict[str, str] = {}
         if self.pager:
             parameters.update(self.pager.get_parameters())
 

--- a/paddle_billing/Resources/Transactions/TransactionsClient.py
+++ b/paddle_billing/Resources/Transactions/TransactionsClient.py
@@ -31,15 +31,14 @@ class TransactionsClient:
         self.client = client
         self.response = None
 
-    def list(self, operation: ListTransactions = None) -> TransactionCollection:
+    def list(self, operation: ListTransactions | None = None) -> TransactionCollection:
         if operation is None:
             operation = ListTransactions()
 
         self.response = self.client.get_raw("/transactions", operation.get_parameters())
         parser = ResponseParser(self.response)
-
         return TransactionCollection.from_list(
-            parser.get_data(), Paginator(self.client, parser.get_pagination(), TransactionCollection)
+            parser.get_list(), Paginator(self.client, parser.get_pagination(), TransactionCollection)
         )
 
     def get(self, transaction_id: str, includes=None) -> Transaction:
@@ -55,8 +54,7 @@ class TransactionsClient:
         params = {"include": ",".join(include.value for include in includes)} if includes else {}
         self.response = self.client.get_raw(f"/transactions/{transaction_id}", params)
         parser = ResponseParser(self.response)
-
-        return Transaction.from_dict(parser.get_data())
+        return Transaction.from_dict(parser.get_dict())
 
     def create(self, operation: CreateTransaction, includes=None) -> Transaction:
         if includes is None:
@@ -72,13 +70,13 @@ class TransactionsClient:
         self.response = self.client.post_raw("/transactions", operation, params)
         parser = ResponseParser(self.response)
 
-        return Transaction.from_dict(parser.get_data())
+        return Transaction.from_dict(parser.get_dict())
 
     def update(self, transaction_id: str, operation: UpdateTransaction) -> Transaction:
         self.response = self.client.patch_raw(f"/transactions/{transaction_id}", operation)
         parser = ResponseParser(self.response)
 
-        return Transaction.from_dict(parser.get_data())
+        return Transaction.from_dict(parser.get_dict())
 
     def preview(
         self,
@@ -89,16 +87,16 @@ class TransactionsClient:
         self.response = self.client.post_raw("/transactions/preview", operation)
         parser = ResponseParser(self.response)
 
-        return TransactionPreview.from_dict(parser.get_data())
+        return TransactionPreview.from_dict(parser.get_dict())
 
-    def get_invoice_pdf(self, transaction_id: str, operation: GetTransactionInvoice = None) -> TransactionData:
+    def get_invoice_pdf(self, transaction_id: str, operation: GetTransactionInvoice | None = None) -> TransactionData:
         self.response = self.client.get_raw(f"/transactions/{transaction_id}/invoice", operation)
         parser = ResponseParser(self.response)
 
-        return TransactionData.from_dict(parser.get_data())
+        return TransactionData.from_dict(parser.get_dict())
 
     def revise(self, transaction_id: str, operation: ReviseTransaction) -> Transaction:
         self.response = self.client.post_raw(f"/transactions/{transaction_id}/revise", operation)
         parser = ResponseParser(self.response)
 
-        return Transaction.from_dict(parser.get_data())
+        return Transaction.from_dict(parser.get_dict())

--- a/paddle_billing/ResponseParser.py
+++ b/paddle_billing/ResponseParser.py
@@ -28,12 +28,10 @@ class ResponseParser:
         return self.body.get("data", []) if self.body else []
 
     def get_list(self) -> list[Any]:
-        data = self.body.get("data", []) if self.body else []
-        return data
+        return self.get_data()
 
     def get_dict(self) -> dict[str, Any]:
-        data = self.body.get("data", []) if self.body else []
-        return data
+        return self.get_data()
 
     def get_error(self) -> ApiError | None:
         return self.error

--- a/paddle_billing/ResponseParser.py
+++ b/paddle_billing/ResponseParser.py
@@ -1,5 +1,6 @@
 import json
 from requests import Response
+from typing import cast, Any
 
 from paddle_billing.Entities.Shared import Pagination
 
@@ -23,8 +24,16 @@ class ResponseParser:
         if self.body and "error" in self.body:
             self.error = self.parse_errors()
 
-    def get_data(self) -> list | dict:
+    def get_data(self) -> list[Any] | dict[str, Any]:
         return self.body.get("data", []) if self.body else []
+
+    def get_list(self) -> list[Any]:
+        data = self.body.get("data", []) if self.body else []
+        return data
+
+    def get_dict(self) -> dict[str, Any]:
+        data = self.body.get("data", []) if self.body else []
+        return data
 
     def get_error(self) -> ApiError | None:
         return self.error
@@ -34,10 +43,10 @@ class ResponseParser:
         pagination = meta.get("pagination", {}) if meta else {}
 
         return Pagination(
-            per_page=pagination.get("per_page"),
-            next=pagination.get("next"),
-            has_more=pagination.get("has_more"),
-            estimated_total=pagination.get("estimated_total"),
+            per_page=cast(int, pagination.get("per_page")),
+            next=cast(str, pagination.get("next")),
+            has_more=cast(bool, pagination.get("has_more")),
+            estimated_total=cast(int, pagination.get("estimated_total")),
         )
 
     def parse_errors(self) -> ApiError | None:

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,11 +1,6 @@
 {
   "typeCheckingMode": "basic",
-  // "reportGeneralTypeIssues": false,
-  "reportUnknownVariableType": false,
-  "reportUnknownMemberType": false,
-  "reportUntypedFunctionDecorator": false,
-  "reportMissingTypeStubs": false,
-  "reportArgumentType": false,
+  // "reportArgumentType": false,
   "reportAssignmentType": false,
   "reportAttributeAccessIssue": false,
   "reportOperatorIssue": false,

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,6 @@
 {
   "typeCheckingMode": "basic",
-  // "reportArgumentType": false,
+  "reportMissingTypeArgument": true,
   "reportAssignmentType": false,
   "reportAttributeAccessIssue": false,
   "reportOperatorIssue": false,

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,17 @@
+{
+  "typeCheckingMode": "basic",
+  // "reportGeneralTypeIssues": false,
+  "reportUnknownVariableType": false,
+  "reportUnknownMemberType": false,
+  "reportUntypedFunctionDecorator": false,
+  "reportMissingTypeStubs": false,
+  "reportArgumentType": false,
+  "reportAssignmentType": false,
+  "reportAttributeAccessIssue": false,
+  "reportOperatorIssue": false,
+  "reportOptionalMemberAccess": false,
+  "reportOptionalSubscript": false,
+  "reportCallIssue": false,
+  "reportReturnType": false,
+  "reportOptionalIterable": false
+}

--- a/tests/Unit/PaddleStrEnum/test_PaddleStrEnum.py
+++ b/tests/Unit/PaddleStrEnum/test_PaddleStrEnum.py
@@ -29,7 +29,7 @@ def test_dataclass_asdict_returns_expected_paddle_str_enum_value():
     class TestDataclass:
         country_code: TestCountryCodesEnum = None
 
-        def get_parameters(self) -> dict:
+        def get_parameters(self) -> dict[str, str]:
             return asdict(self)
 
     test_dataclass = TestDataclass(TestCountryCodesEnum.CA)


### PR DESCRIPTION
Sorry for the massive PR  👀

## Summary
The aim of this PR is to improve type hints. #95 

Fixing some typing errors as well as adding generics

```python
# this
foo: str = None
bar: dict = {}

# becomes (for example)
foo: str | None = None
bar: dict[str, Any] = {}
```

I used Pyright for type checking. I commited the pyrightconfig.json so my config can be duplicated.

In most places, I could not deduce the correct generics, so Any is used liberally.
Moving forward these could slowly be made more specific.

## Behavioral Changes
I did my best to avoid making behavior changes in 99% of cases.

There are a few cases where I introduced changes that could modify behavior. Here are a few:
*paddle_billing/Entities/Notifications/NotificationEvent.py:45* -> raise error
*paddle_billing/Notifications/Verifier.py:53* -> raise error

*paddle_billing/ResponseParser.py:*
Two methods were added: `get_list` and `get_dict`.
Both of these are just wrappers for `get_data` but with the correct type *annotations*. `get_dict` will still return a list from `get_data` if the `body` is None. This should probably be looked at.

*paddle_billing/Notifications/Entities/Entity.py* & *paddle_billing/Notifications/Entities/Simulations/SimulationEntity.py*
Added `type(entity_class) is not type`.


Open to any feedback also.