### PR TITLE
docs: Release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [Unreleased]
+## 1.6.1 - 2025-06-10
 
 ### Fixed
 - Fixed JSON encoding of undefined notification entities
   - `paddle_billing.Notifications.Entities.UndefinedEntity` now implements `to_json` and can be encoded using `paddle_billing.Json.PayloadEncoder`
+- Improved type hints throughout SDK
 
 ## 1.6.0 - 2025-02-10
 

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -196,7 +196,7 @@ class Client:
                 "Authorization": f"Bearer {self.__api_key}",
                 "Content-Type": "application/json",
                 "Paddle-Version": str(self.use_api_version),
-                "User-Agent": "PaddleSDK/python 1.6.0",
+                "User-Agent": "PaddleSDK/python 1.6.1",
             }
         )
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version="1.6.0",
+    version="1.6.1",
     author="Paddle and contributors",
     author_email="team-dx@paddle.com",
     description="Paddle's Python SDK for Paddle Billing",


### PR DESCRIPTION
https://github.com/PaddleHQ/paddle-python-sdk/compare/v1.6.1...docs/release-1.6.1

---

## 1.6.1 - 2025-06-10

### Fixed
- Fixed JSON encoding of undefined notification entities
  - `paddle_billing.Notifications.Entities.UndefinedEntity` now implements `to_json` and can be encoded using `paddle_billing.Json.PayloadEncoder`
- Improved type hints throughout SDK