### PR TITLE
feat: Add `exchange_rate` and `fee_rate` to payout totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [Unreleased]
+
+### Added
+
+- Added `exchange_rate` and `fee_rate` to `TransactionPayoutTotals`
+- Added `exchange_rate` to `TransactionPayoutTotalsAdjusted`
+
 ## 1.8.0 - 2025-07-09
 
 ### Added

--- a/paddle_billing/Entities/Shared/TransactionPayoutTotals.py
+++ b/paddle_billing/Entities/Shared/TransactionPayoutTotals.py
@@ -18,6 +18,8 @@ class TransactionPayoutTotals:
     earnings: str | None
     currency_code: CurrencyCodePayouts
     credit_to_balance: str
+    exchange_rate: str
+    fee_rate: str
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> TransactionPayoutTotals:
@@ -33,4 +35,6 @@ class TransactionPayoutTotals:
             earnings=data.get("earnings"),
             currency_code=CurrencyCodePayouts(data["currency_code"]),
             credit_to_balance=data["credit_to_balance"],
+            exchange_rate=data["exchange_rate"],
+            fee_rate=data["fee_rate"],
         )

--- a/paddle_billing/Entities/Shared/TransactionPayoutTotalsAdjusted.py
+++ b/paddle_billing/Entities/Shared/TransactionPayoutTotalsAdjusted.py
@@ -15,6 +15,7 @@ class TransactionPayoutTotalsAdjusted:
     chargeback_fee: ChargebackFee
     earnings: str
     currency_code: CurrencyCodePayouts
+    exchange_rate: str
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> TransactionPayoutTotalsAdjusted:
@@ -26,4 +27,5 @@ class TransactionPayoutTotalsAdjusted:
             chargeback_fee=ChargebackFee.from_dict(data["chargeback_fee"]),
             earnings=data["earnings"],
             currency_code=CurrencyCodePayouts(data["currency_code"]),
+            exchange_rate=data["exchange_rate"],
         )

--- a/paddle_billing/Notifications/Entities/Shared/TransactionPayoutTotals.py
+++ b/paddle_billing/Notifications/Entities/Shared/TransactionPayoutTotals.py
@@ -18,6 +18,8 @@ class TransactionPayoutTotals:
     earnings: str | None
     currency_code: CurrencyCodePayouts
     credit_to_balance: str
+    exchange_rate: str | None
+    fee_rate: str | None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> TransactionPayoutTotals:
@@ -33,4 +35,6 @@ class TransactionPayoutTotals:
             earnings=data.get("earnings"),
             currency_code=CurrencyCodePayouts(data["currency_code"]),
             credit_to_balance=data["credit_to_balance"],
+            exchange_rate=data.get("exchange_rate"),
+            fee_rate=data.get("fee_rate"),
         )

--- a/paddle_billing/Notifications/Entities/Shared/TransactionPayoutTotalsAdjusted.py
+++ b/paddle_billing/Notifications/Entities/Shared/TransactionPayoutTotalsAdjusted.py
@@ -15,6 +15,7 @@ class TransactionPayoutTotalsAdjusted:
     chargeback_fee: ChargebackFee
     earnings: str
     currency_code: CurrencyCodePayouts
+    exchange_rate: str | None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> TransactionPayoutTotalsAdjusted:
@@ -26,4 +27,5 @@ class TransactionPayoutTotalsAdjusted:
             chargeback_fee=ChargebackFee.from_dict(data["chargeback_fee"]),
             earnings=data["earnings"],
             currency_code=CurrencyCodePayouts(data["currency_code"]),
+            exchange_rate=data.get("exchange_rate"),
         )

--- a/tests/Functional/Resources/Simulations/_fixtures/payload/transaction.completed.json
+++ b/tests/Functional/Resources/Simulations/_fixtures/payload/transaction.completed.json
@@ -231,7 +231,9 @@
             "subtotal": "59900",
             "grand_total": "65215",
             "currency_code": "USD",
-            "credit_to_balance": "0"
+            "credit_to_balance": "0",
+            "exchange_rate": "0.70194147",
+            "fee_rate": "0"
         },
         "tax_rates_used": [
             {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
@@ -878,7 +878,9 @@
           "grand_total": "40000",
           "fee": "2050",
           "earnings": "37950",
-          "currency_code": "USD"
+          "currency_code": "USD",
+          "exchange_rate": "0.70194147",
+          "fee_rate": "0"
         },
         "adjusted_payout_totals": {
           "subtotal": "40000",
@@ -890,7 +892,8 @@
             "original": null
           },
           "earnings": "37950",
-          "currency_code": "USD"
+          "currency_code": "USD",
+          "exchange_rate": "0.70194147"
         },
         "line_items": [
           {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
@@ -864,7 +864,9 @@
           "grand_total": "40000",
           "fee": "2050",
           "earnings": "37950",
-          "currency_code": "USD"
+          "currency_code": "USD",
+          "exchange_rate": "0.70194147",
+          "fee_rate": "0"
         },
         "adjusted_payout_totals": {
           "subtotal": "40000",
@@ -876,7 +878,8 @@
             "original": null
           },
           "earnings": "37950",
-          "currency_code": "USD"
+          "currency_code": "USD",
+          "exchange_rate": "0.70194147"
         },
         "line_items": [
           {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
@@ -864,7 +864,9 @@
           "grand_total": "40000",
           "fee": "2050",
           "earnings": "37950",
-          "currency_code": "USD"
+          "currency_code": "USD",
+          "exchange_rate": "0.70194147",
+          "fee_rate": "0"
         },
         "adjusted_payout_totals": {
           "subtotal": "40000",
@@ -876,7 +878,8 @@
             "original": null
           },
           "earnings": "37950",
-          "currency_code": "USD"
+          "currency_code": "USD",
+          "exchange_rate": "0.70194147"
         },
         "line_items": [
           {

--- a/tests/Unit/Entities/_fixtures/notification/entity/transaction.completed.json
+++ b/tests/Unit/Entities/_fixtures/notification/entity/transaction.completed.json
@@ -231,7 +231,9 @@
             "subtotal": "59900",
             "grand_total": "65215",
             "currency_code": "USD",
-            "credit_to_balance": "0"
+            "credit_to_balance": "0",
+            "exchange_rate": "0.70194147",
+            "fee_rate": "0"
         },
         "tax_rates_used": [
             {

--- a/tests/Unit/Entities/_fixtures/notification/entity/transaction.revised.json
+++ b/tests/Unit/Entities/_fixtures/notification/entity/transaction.revised.json
@@ -231,7 +231,9 @@
             "subtotal": "59900",
             "grand_total": "65215",
             "currency_code": "USD",
-            "credit_to_balance": "0"
+            "credit_to_balance": "0",
+            "exchange_rate": "0.70194147",
+            "fee_rate": "0"
         },
         "tax_rates_used": [
             {
@@ -244,7 +246,19 @@
                 "tax_rate": "0.08875"
             }
         ],
-        "adjusted_payout_totals": null,
+        "adjusted_payout_totals": {
+            "fee": "3311",
+            "tax": "5315",
+            "total": "65215",
+            "chargeback_fee": {
+                "amount": "0",
+                "original": null
+            },
+            "earnings": "56589",
+            "subtotal": "59900",
+            "currency_code": "USD",
+            "exchange_rate": "0.70194147"
+        },
         "adjusted_totals": {
             "fee": "3311",
             "tax": "5315",


### PR DESCRIPTION
### Added

- Added `exchange_rate` and `fee_rate` to `TransactionPayoutTotals`
- Added `exchange_rate` to `TransactionPayoutTotalsAdjusted`