### PR TITLE
docs(release): v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [Unreleased]
+## 1.10.0 - 2025-08-15
 
 ### Added
 

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -200,7 +200,7 @@ class Client:
                 "Authorization": f"Bearer {self.__api_key}",
                 "Content-Type": "application/json",
                 "Paddle-Version": str(self.use_api_version),
-                "User-Agent": "PaddleSDK/python 1.9.0",
+                "User-Agent": "PaddleSDK/python 1.10.0",
             }
         )
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version="1.9.0",
+    version="1.10.0",
     author="Paddle and contributors",
     author_email="team-dx@paddle.com",
     description="Paddle's Python SDK for Paddle Billing",

--- a/tests/Functional/Resources/ClientToken/test_ClientTokensClient.py
+++ b/tests/Functional/Resources/ClientToken/test_ClientTokensClient.py
@@ -2,7 +2,7 @@ from json import loads
 from pytest import mark
 from urllib.parse import unquote
 
-from build.lib.paddle_billing.Json import PayloadEncoder
+from paddle_billing.Json import PayloadEncoder
 from paddle_billing.Entities.Collections import ClientTokenCollection
 from paddle_billing.Entities.ClientToken import ClientToken
 from paddle_billing.Entities.ClientTokens import ClientTokenStatus

--- a/tests/Functional/Resources/Discounts/test_DiscountsClient.py
+++ b/tests/Functional/Resources/Discounts/test_DiscountsClient.py
@@ -2,7 +2,7 @@ from json import loads
 from pytest import mark
 from urllib.parse import unquote
 
-from build.lib.paddle_billing.Json import PayloadEncoder
+from paddle_billing.Json import PayloadEncoder
 from paddle_billing.Entities.Collections import DiscountCollection
 from paddle_billing.Entities.DateTime import DateTime
 from paddle_billing.Entities.Discount import Discount, DiscountMode

--- a/tests/Unit/Resources/Events/Operations/test_ListEvents.py
+++ b/tests/Unit/Resources/Events/Operations/test_ListEvents.py
@@ -1,6 +1,6 @@
 from pytest import raises
 
-from build.lib.paddle_billing.Resources.Events.Operations import ListEvents
+from paddle_billing.Resources.Events.Operations import ListEvents
 
 from paddle_billing.Exceptions.SdkExceptions.InvalidArgumentException import InvalidArgumentException
 


### PR DESCRIPTION
## 1.10.0 - 2025-08-15

### Added

- Added support for filtering events by `event_type` in event list operation, see [related changelog](https://developer.paddle.com/changelog/2025/filter-events-by-type?utm_source=dx&utm_medium=paddle-python-sdk).

---

https://github.com/PaddleHQ/paddle-python-sdk/compare/v1.9.0...docs/release-1-10-0