### PR TITLE
fix: Instantiate null logger once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-python-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.14.1 - 2026-04-21
+
+### Fixed
+
+- Fixed a handler leak in `Client.null_logger()` where a new `NullHandler` was attached to the shared `"null_logger"` logger on every `Client` instantiation. The `NullHandler` is now only attached when the logger has no handlers configured.
+
 ## 1.14.0 - 2026-03-30
 
 ### Added

--- a/paddle_billing/Client.py
+++ b/paddle_billing/Client.py
@@ -104,7 +104,8 @@ class Client:
         """
 
         null_logger = getLogger("null_logger")
-        null_logger.addHandler(NullHandler())
+        if not null_logger.handlers:
+            null_logger.addHandler(NullHandler())
 
         return null_logger
 
@@ -202,7 +203,7 @@ class Client:
                 "Authorization": f"Bearer {self.__api_key}",
                 "Content-Type": "application/json",
                 "Paddle-Version": str(self.use_api_version),
-                "User-Agent": "PaddleSDK/python 1.14.0",
+                "User-Agent": "PaddleSDK/python 1.14.1",
             }
         )
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    version="1.14.0",
+    version="1.14.1",
     author="Paddle and contributors",
     author_email="team-dx@paddle.com",
     description="Paddle's Python SDK for Paddle Billing",


### PR DESCRIPTION
### Fixed

- Fixed a handler leak in `Client.null_logger()` where a new `NullHandler` was attached to the shared `"null_logger"` logger on every `Client` instantiation. The `NullHandler` is now only attached when the logger has no handlers configured.